### PR TITLE
Quest backend migration and schema update

### DIFF
--- a/backend/src/db/migrations/0011_thankful_steel_serpent.sql
+++ b/backend/src/db/migrations/0011_thankful_steel_serpent.sql
@@ -1,0 +1,59 @@
+CREATE TABLE "quest_stats" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"quest_id" uuid NOT NULL,
+	"stat_id" uuid NOT NULL,
+	"bonus_xp_amount" integer DEFAULT 10 NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "quest_task_stats" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"task_id" uuid NOT NULL,
+	"stat_id" uuid NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "quest_tasks" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"quest_id" uuid NOT NULL,
+	"title" varchar(255) NOT NULL,
+	"description" text,
+	"due_date" timestamp with time zone,
+	"is_completed" boolean DEFAULT false NOT NULL,
+	"completed_at" timestamp with time zone,
+	"xp_amount" integer DEFAULT 5 NOT NULL,
+	"order" integer DEFAULT 0 NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "quests" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"title" varchar(255) NOT NULL,
+	"description" text,
+	"start_date" timestamp with time zone NOT NULL,
+	"end_date" timestamp with time zone NOT NULL,
+	"is_active" boolean DEFAULT true NOT NULL,
+	"is_completed" boolean DEFAULT false NOT NULL,
+	"is_expired" boolean DEFAULT false NOT NULL,
+	"is_archived" boolean DEFAULT false NOT NULL,
+	"bonus_xp_awarded" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "quest_stats" ADD CONSTRAINT "quest_stats_quest_id_quests_id_fk" FOREIGN KEY ("quest_id") REFERENCES "public"."quests"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "quest_stats" ADD CONSTRAINT "quest_stats_stat_id_character_stats_id_fk" FOREIGN KEY ("stat_id") REFERENCES "public"."character_stats"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "quest_task_stats" ADD CONSTRAINT "quest_task_stats_task_id_quest_tasks_id_fk" FOREIGN KEY ("task_id") REFERENCES "public"."quest_tasks"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "quest_task_stats" ADD CONSTRAINT "quest_task_stats_stat_id_character_stats_id_fk" FOREIGN KEY ("stat_id") REFERENCES "public"."character_stats"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "quest_tasks" ADD CONSTRAINT "quest_tasks_quest_id_quests_id_fk" FOREIGN KEY ("quest_id") REFERENCES "public"."quests"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "quests" ADD CONSTRAINT "quests_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "quest_stats_quest_id_idx" ON "quest_stats" USING btree ("quest_id");--> statement-breakpoint
+CREATE INDEX "quest_stats_stat_id_idx" ON "quest_stats" USING btree ("stat_id");--> statement-breakpoint
+CREATE INDEX "quest_task_stats_task_id_idx" ON "quest_task_stats" USING btree ("task_id");--> statement-breakpoint
+CREATE INDEX "quest_task_stats_stat_id_idx" ON "quest_task_stats" USING btree ("stat_id");--> statement-breakpoint
+CREATE INDEX "quest_tasks_quest_id_idx" ON "quest_tasks" USING btree ("quest_id");--> statement-breakpoint
+CREATE INDEX "quest_tasks_order_idx" ON "quest_tasks" USING btree ("quest_id","order");--> statement-breakpoint
+CREATE INDEX "quests_user_id_idx" ON "quests" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "quests_active_idx" ON "quests" USING btree ("is_active");

--- a/backend/src/db/migrations/meta/0011_snapshot.json
+++ b/backend/src/db/migrations/meta/0011_snapshot.json
@@ -1,0 +1,1652 @@
+{
+  "id": "68f97b7c-5b06-4735-9220-d38a190e3e36",
+  "prevId": "8b1f5155-8ac1-47f7-9399-f868f46117b3",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.characters": {
+      "name": "characters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_class": {
+          "name": "character_class",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backstory": {
+          "name": "backstory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goals": {
+          "name": "goals",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "motto": {
+          "name": "motto",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "characters_user_id_users_id_fk": {
+          "name": "characters_user_id_users_id_fk",
+          "tableFrom": "characters",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.character_stat_level_titles": {
+      "name": "character_stat_level_titles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "stat_id": {
+          "name": "stat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "character_stat_level_titles_stat_id_character_stats_id_fk": {
+          "name": "character_stat_level_titles_stat_id_character_stats_id_fk",
+          "tableFrom": "character_stat_level_titles",
+          "tableTo": "character_stats",
+          "columnsFrom": [
+            "stat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.character_stat_xp_grants": {
+      "name": "character_stat_xp_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stat_id": {
+          "name": "stat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "xp_amount": {
+          "name": "xp_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "character_stat_xp_grants_user_id_users_id_fk": {
+          "name": "character_stat_xp_grants_user_id_users_id_fk",
+          "tableFrom": "character_stat_xp_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "character_stat_xp_grants_stat_id_character_stats_id_fk": {
+          "name": "character_stat_xp_grants_stat_id_character_stats_id_fk",
+          "tableFrom": "character_stat_xp_grants",
+          "tableTo": "character_stats",
+          "columnsFrom": [
+            "stat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.character_stats": {
+      "name": "character_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "example_activities": {
+          "name": "example_activities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "current_level": {
+          "name": "current_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "total_xp": {
+          "name": "total_xp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "character_stats_user_id_users_id_fk": {
+          "name": "character_stats_user_id_users_id_fk",
+          "tableFrom": "character_stats",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.goals": {
+      "name": "goals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "goals_user_id_users_id_fk": {
+          "name": "goals_user_id_users_id_fk",
+          "tableFrom": "goals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.family_members": {
+      "name": "family_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relationship": {
+          "name": "relationship",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birthday": {
+          "name": "birthday",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "likes": {
+          "name": "likes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dislikes": {
+          "name": "dislikes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "energy_level": {
+          "name": "energy_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 50
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_interaction_date": {
+          "name": "last_interaction_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection_xp": {
+          "name": "connection_xp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "connection_level": {
+          "name": "connection_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "family_members_user_id_users_id_fk": {
+          "name": "family_members_user_id_users_id_fk",
+          "tableFrom": "family_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.family_task_feedback": {
+      "name": "family_task_feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "family_member_id": {
+          "name": "family_member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_description": {
+          "name": "task_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enjoyed_it": {
+          "name": "enjoyed_it",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "xp_granted": {
+          "name": "xp_granted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "family_task_feedback_user_id_users_id_fk": {
+          "name": "family_task_feedback_user_id_users_id_fk",
+          "tableFrom": "family_task_feedback",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "family_task_feedback_family_member_id_family_members_id_fk": {
+          "name": "family_task_feedback_family_member_id_family_members_id_fk",
+          "tableFrom": "family_task_feedback",
+          "tableTo": "family_members",
+          "columnsFrom": [
+            "family_member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.goal_tags": {
+      "name": "goal_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "goal_id": {
+          "name": "goal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "goal_tags_goal_id_goals_id_fk": {
+          "name": "goal_tags_goal_id_goals_id_fk",
+          "tableFrom": "goal_tags",
+          "tableTo": "goals",
+          "columnsFrom": [
+            "goal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "goal_tags_tag_id_tags_id_fk": {
+          "name": "goal_tags_tag_id_tags_id_fk",
+          "tableFrom": "goal_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tags_user_id_users_id_fk": {
+          "name": "tags_user_id_users_id_fk",
+          "tableFrom": "tags",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_tag": {
+          "name": "unique_user_tag",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.journal_conversation_messages": {
+      "name": "journal_conversation_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_order": {
+          "name": "message_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "journal_conversation_messages_entry_id_journal_entries_id_fk": {
+          "name": "journal_conversation_messages_entry_id_journal_entries_id_fk",
+          "tableFrom": "journal_conversation_messages",
+          "tableTo": "journal_entries",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.journal_entries": {
+      "name": "journal_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synopsis": {
+          "name": "synopsis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "journal_entries_user_id_users_id_fk": {
+          "name": "journal_entries_user_id_users_id_fk",
+          "tableFrom": "journal_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.journal_entry_stat_tags": {
+      "name": "journal_entry_stat_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stat_id": {
+          "name": "stat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "journal_entry_stat_tags_entry_id_journal_entries_id_fk": {
+          "name": "journal_entry_stat_tags_entry_id_journal_entries_id_fk",
+          "tableFrom": "journal_entry_stat_tags",
+          "tableTo": "journal_entries",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "journal_entry_stat_tags_stat_id_character_stats_id_fk": {
+          "name": "journal_entry_stat_tags_stat_id_character_stats_id_fk",
+          "tableFrom": "journal_entry_stat_tags",
+          "tableTo": "character_stats",
+          "columnsFrom": [
+            "stat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.journal_entry_tags": {
+      "name": "journal_entry_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "journal_entry_tags_entry_id_journal_entries_id_fk": {
+          "name": "journal_entry_tags_entry_id_journal_entries_id_fk",
+          "tableFrom": "journal_entry_tags",
+          "tableTo": "journal_entries",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "journal_entry_tags_tag_id_tags_id_fk": {
+          "name": "journal_entry_tags_tag_id_tags_id_fk",
+          "tableFrom": "journal_entry_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.journal_sessions": {
+      "name": "journal_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messages": {
+          "name": "messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'true'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "journal_sessions_user_id_users_id_fk": {
+          "name": "journal_sessions_user_id_users_id_fk",
+          "tableFrom": "journal_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quest_stats": {
+      "name": "quest_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "quest_id": {
+          "name": "quest_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stat_id": {
+          "name": "stat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bonus_xp_amount": {
+          "name": "bonus_xp_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "quest_stats_quest_id_idx": {
+          "name": "quest_stats_quest_id_idx",
+          "columns": [
+            {
+              "expression": "quest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "quest_stats_stat_id_idx": {
+          "name": "quest_stats_stat_id_idx",
+          "columns": [
+            {
+              "expression": "stat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "quest_stats_quest_id_quests_id_fk": {
+          "name": "quest_stats_quest_id_quests_id_fk",
+          "tableFrom": "quest_stats",
+          "tableTo": "quests",
+          "columnsFrom": [
+            "quest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "quest_stats_stat_id_character_stats_id_fk": {
+          "name": "quest_stats_stat_id_character_stats_id_fk",
+          "tableFrom": "quest_stats",
+          "tableTo": "character_stats",
+          "columnsFrom": [
+            "stat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quest_task_stats": {
+      "name": "quest_task_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stat_id": {
+          "name": "stat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "quest_task_stats_task_id_idx": {
+          "name": "quest_task_stats_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "quest_task_stats_stat_id_idx": {
+          "name": "quest_task_stats_stat_id_idx",
+          "columns": [
+            {
+              "expression": "stat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "quest_task_stats_task_id_quest_tasks_id_fk": {
+          "name": "quest_task_stats_task_id_quest_tasks_id_fk",
+          "tableFrom": "quest_task_stats",
+          "tableTo": "quest_tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "quest_task_stats_stat_id_character_stats_id_fk": {
+          "name": "quest_task_stats_stat_id_character_stats_id_fk",
+          "tableFrom": "quest_task_stats",
+          "tableTo": "character_stats",
+          "columnsFrom": [
+            "stat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quest_tasks": {
+      "name": "quest_tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "quest_id": {
+          "name": "quest_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_completed": {
+          "name": "is_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "xp_amount": {
+          "name": "xp_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "quest_tasks_quest_id_idx": {
+          "name": "quest_tasks_quest_id_idx",
+          "columns": [
+            {
+              "expression": "quest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "quest_tasks_order_idx": {
+          "name": "quest_tasks_order_idx",
+          "columns": [
+            {
+              "expression": "quest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "quest_tasks_quest_id_quests_id_fk": {
+          "name": "quest_tasks_quest_id_quests_id_fk",
+          "tableFrom": "quest_tasks",
+          "tableTo": "quests",
+          "columnsFrom": [
+            "quest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quests": {
+      "name": "quests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_completed": {
+          "name": "is_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_expired": {
+          "name": "is_expired",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "bonus_xp_awarded": {
+          "name": "bonus_xp_awarded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "quests_user_id_idx": {
+          "name": "quests_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "quests_active_idx": {
+          "name": "quests_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "quests_user_id_users_id_fk": {
+          "name": "quests_user_id_users_id_fk",
+          "tableFrom": "quests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/src/db/migrations/meta/_journal.json
+++ b/backend/src/db/migrations/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1752002549922,
       "tag": "0010_moaning_doctor_doom",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1752020192488,
+      "tag": "0011_thankful_steel_serpent",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -6,6 +6,7 @@ export { userValidationSchema, registerSchema, loginSchema } from '../validation
 export { createGoalSchema, updateGoalSchema } from '../validation/goals';
 export { createFamilyMemberSchema, updateFamilyMemberSchema, createFamilyTaskFeedbackSchema } from '../validation/family';
 export { startJournalSessionSchema, sendJournalMessageSchema, saveJournalEntrySchema, getJournalEntrySchema } from '../validation/journal';
+export { createQuestSchema, updateQuestSchema, createQuestTaskSchema, updateQuestTaskSchema } from '../validation/quests';
 
 // Re-export types for backward compatibility
 export type { User, NewUser, PublicUser } from '../types/users';
@@ -38,3 +39,17 @@ export type {
   JournalEntryWithDetails,
   ChatMessage,
 } from '../types/journal';
+export type {
+  Quest,
+  NewQuest,
+  QuestTask,
+  NewQuestTask,
+  QuestWithTasks,
+  QuestWithProgress,
+  CreateQuestRequest,
+  CreateQuestResponse,
+  GetQuestsResponse,
+  GetQuestResponse,
+  UpdateQuestResponse,
+  CompleteQuestTaskResponse,
+} from '../types/quests';

--- a/backend/src/db/schema/index.ts
+++ b/backend/src/db/schema/index.ts
@@ -6,6 +6,7 @@ export * from './goals';
 export * from './family';
 export * from './tags';
 export * from './journal';
+export * from './quests';
 // Future exports:
 // export * from './posts';
 // export * from './comments';

--- a/backend/src/db/schema/quests.ts
+++ b/backend/src/db/schema/quests.ts
@@ -1,0 +1,76 @@
+import { pgTable, uuid, varchar, text, timestamp, boolean, integer, index } from 'drizzle-orm/pg-core';
+import { users } from './users';
+import { characterStats } from './stats';
+
+// Quests table - long-term challenges with multiple tasks
+export const quests = pgTable('quests', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  userId: uuid('user_id')
+    .notNull()
+    .references(() => users.id, { onDelete: 'cascade' }),
+  title: varchar('title', { length: 255 }).notNull(),
+  description: text('description'),
+  startDate: timestamp('start_date', { withTimezone: true }).notNull(),
+  endDate: timestamp('end_date', { withTimezone: true }).notNull(),
+  isActive: boolean('is_active').default(true).notNull(),
+  isCompleted: boolean('is_completed').default(false).notNull(),
+  isExpired: boolean('is_expired').default(false).notNull(),
+  isArchived: boolean('is_archived').default(false).notNull(),
+  bonusXpAwarded: boolean('bonus_xp_awarded').default(false).notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+}, (table) => ({
+  userIdIdx: index('quests_user_id_idx').on(table.userId),
+  activeIdx: index('quests_active_idx').on(table.isActive),
+}));
+
+// Quest stats - which stats this quest grants XP to
+export const questStats = pgTable('quest_stats', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  questId: uuid('quest_id')
+    .notNull()
+    .references(() => quests.id, { onDelete: 'cascade' }),
+  statId: uuid('stat_id')
+    .notNull()
+    .references(() => characterStats.id, { onDelete: 'cascade' }),
+  bonusXpAmount: integer('bonus_xp_amount').default(10).notNull(), // XP awarded on quest completion
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+}, (table) => ({
+  questIdIdx: index('quest_stats_quest_id_idx').on(table.questId),
+  statIdIdx: index('quest_stats_stat_id_idx').on(table.statId),
+}));
+
+// Quest tasks - individual tasks that make up a quest
+export const questTasks = pgTable('quest_tasks', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  questId: uuid('quest_id')
+    .notNull()
+    .references(() => quests.id, { onDelete: 'cascade' }),
+  title: varchar('title', { length: 255 }).notNull(),
+  description: text('description'),
+  dueDate: timestamp('due_date', { withTimezone: true }), // Optional due date for individual tasks
+  isCompleted: boolean('is_completed').default(false).notNull(),
+  completedAt: timestamp('completed_at', { withTimezone: true }),
+  xpAmount: integer('xp_amount').default(5).notNull(), // XP granted when task is completed
+  order: integer('order').default(0).notNull(), // For ordering tasks within a quest
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+}, (table) => ({
+  questIdIdx: index('quest_tasks_quest_id_idx').on(table.questId),
+  orderIdx: index('quest_tasks_order_idx').on(table.questId, table.order),
+}));
+
+// Quest task stats - which stats each task grants XP to (many-to-many)
+export const questTaskStats = pgTable('quest_task_stats', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  taskId: uuid('task_id')
+    .notNull()
+    .references(() => questTasks.id, { onDelete: 'cascade' }),
+  statId: uuid('stat_id')
+    .notNull()
+    .references(() => characterStats.id, { onDelete: 'cascade' }),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+}, (table) => ({
+  taskIdIdx: index('quest_task_stats_task_id_idx').on(table.taskId),
+  statIdIdx: index('quest_task_stats_stat_id_idx').on(table.statId),
+}));

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -4,6 +4,7 @@ export * from './stats';
 export * from './goals';
 export * from './family';
 export * from './tags';
+export * from './quests';
 // Future exports:
 // export * from './posts';
 // export * from './auth';

--- a/backend/src/types/quests.ts
+++ b/backend/src/types/quests.ts
@@ -1,0 +1,117 @@
+import type { quests, questStats, questTasks, questTaskStats } from '../db/schema/quests';
+
+// Base quest types
+export type Quest = typeof quests.$inferSelect;
+export type NewQuest = typeof quests.$inferInsert;
+
+// Quest stats types
+export type QuestStat = typeof questStats.$inferSelect;
+export type NewQuestStat = typeof questStats.$inferInsert;
+
+// Quest task types
+export type QuestTask = typeof questTasks.$inferSelect;
+export type NewQuestTask = typeof questTasks.$inferInsert;
+
+// Quest task stats types
+export type QuestTaskStat = typeof questTaskStats.$inferSelect;
+export type NewQuestTaskStat = typeof questTaskStats.$inferInsert;
+
+// Enhanced types with related data
+export interface QuestWithTasks extends Quest {
+  tasks: QuestTask[];
+  stats: QuestStat[];
+}
+
+export interface QuestTaskWithStats extends QuestTask {
+  stats: QuestTaskStat[];
+}
+
+export interface QuestWithProgress extends Quest {
+  tasks: QuestTaskWithStats[];
+  stats: QuestStat[];
+  completedTasksCount: number;
+  totalTasksCount: number;
+  progressPercentage: number;
+  xpEarned: number;
+  timeRemaining: number; // in milliseconds
+  isExpiredDerived: boolean; // calculated based on current time vs endDate
+}
+
+// Request/Response types for API
+export interface CreateQuestRequest {
+  title: string;
+  description?: string;
+  startDate: string; // ISO string
+  endDate: string; // ISO string
+  tasks: CreateQuestTaskRequest[];
+  statIds: string[]; // Stats that get bonus XP on quest completion
+}
+
+export interface CreateQuestTaskRequest {
+  title: string;
+  description?: string;
+  dueDate?: string; // ISO string
+  xpAmount?: number;
+  statIds: string[]; // Stats that get XP when this task is completed
+  order?: number;
+}
+
+export interface UpdateQuestRequest {
+  title?: string;
+  description?: string;
+  startDate?: string; // ISO string
+  endDate?: string; // ISO string
+  isActive?: boolean;
+  isArchived?: boolean;
+}
+
+export interface UpdateQuestTaskRequest {
+  title?: string;
+  description?: string;
+  dueDate?: string; // ISO string
+  xpAmount?: number;
+  order?: number;
+  isCompleted?: boolean;
+}
+
+export interface CreateQuestResponse {
+  success: boolean;
+  data: QuestWithTasks;
+}
+
+export interface GetQuestsResponse {
+  success: boolean;
+  data: QuestWithProgress[];
+}
+
+export interface GetQuestResponse {
+  success: boolean;
+  data: QuestWithProgress;
+}
+
+export interface UpdateQuestResponse {
+  success: boolean;
+  data: QuestWithTasks;
+}
+
+export interface CompleteQuestTaskResponse {
+  success: boolean;
+  data: {
+    task: QuestTask;
+    xpGranted: Array<{
+      statId: string;
+      statName: string;
+      xpAmount: number;
+    }>;
+    questCompleted?: boolean;
+    bonusXpGranted?: Array<{
+      statId: string;
+      statName: string;
+      xpAmount: number;
+    }>;
+  };
+}
+
+export interface DeleteQuestResponse {
+  success: boolean;
+}

--- a/backend/src/validation/quests.ts
+++ b/backend/src/validation/quests.ts
@@ -1,0 +1,72 @@
+import { z } from 'zod';
+
+// Quest validation schemas
+export const createQuestTaskSchema = z.object({
+  title: z.string().min(1, 'Task title is required').max(255, 'Task title must be 255 characters or less'),
+  description: z.string().optional(),
+  dueDate: z.string().datetime().optional(),
+  xpAmount: z.number().int().min(1).max(100).default(5),
+  statIds: z.array(z.string().uuid()).min(1, 'At least one stat must be selected'),
+  order: z.number().int().min(0).optional(),
+});
+
+export const createQuestSchema = z.object({
+  title: z.string().min(1, 'Quest title is required').max(255, 'Quest title must be 255 characters or less'),
+  description: z.string().optional(),
+  startDate: z.string().datetime(),
+  endDate: z.string().datetime(),
+  tasks: z.array(createQuestTaskSchema).min(1, 'At least one task is required'),
+  statIds: z.array(z.string().uuid()).min(1, 'At least one stat must be selected for bonus XP'),
+}).refine((data) => {
+  const startDate = new Date(data.startDate);
+  const endDate = new Date(data.endDate);
+  return endDate > startDate;
+}, {
+  message: 'End date must be after start date',
+  path: ['endDate'],
+});
+
+export const updateQuestSchema = z.object({
+  title: z.string().min(1).max(255).optional(),
+  description: z.string().optional(),
+  startDate: z.string().datetime().optional(),
+  endDate: z.string().datetime().optional(),
+  isActive: z.boolean().optional(),
+  isArchived: z.boolean().optional(),
+}).refine((data) => {
+  if (data.startDate && data.endDate) {
+    const startDate = new Date(data.startDate);
+    const endDate = new Date(data.endDate);
+    return endDate > startDate;
+  }
+  return true;
+}, {
+  message: 'End date must be after start date',
+  path: ['endDate'],
+});
+
+export const updateQuestTaskSchema = z.object({
+  title: z.string().min(1).max(255).optional(),
+  description: z.string().optional(),
+  dueDate: z.string().datetime().optional(),
+  xpAmount: z.number().int().min(1).max(100).optional(),
+  order: z.number().int().min(0).optional(),
+  isCompleted: z.boolean().optional(),
+});
+
+// Parameter validation schemas
+export const questIdSchema = z.object({
+  questId: z.string().uuid(),
+});
+
+export const questTaskIdSchema = z.object({
+  questId: z.string().uuid(),
+  taskId: z.string().uuid(),
+});
+
+// Query parameter schemas
+export const getQuestsQuerySchema = z.object({
+  status: z.enum(['active', 'completed', 'expired', 'archived', 'all']).default('active'),
+  limit: z.coerce.number().int().min(1).max(100).default(10),
+  offset: z.coerce.number().int().min(0).default(0),
+});

--- a/copilot/features/quests.md
+++ b/copilot/features/quests.md
@@ -1,0 +1,66 @@
+### 📌 Issue: Quests (Long-Term Personal Challenges)
+
+**Goal**: Enable users to create, track, and complete quests — structured, multi-day challenges designed to reinforce personal growth and RPG-style character development. Quests assign tasks, grant XP, and help reinforce long-term habits.
+
+---
+
+### 🧩 Feature Requirements
+
+#### 1. **Create Quest**
+
+* User defines:
+
+  * **Title** (e.g., "Reconnect with Nature")
+  * **Description** (freeform)
+  * **Start Date** and **End Date**
+  * **Tasks** (e.g., “Complete 7 hikes” or “Practice piano 10 times”)
+
+    * Each task has a title, optional due date, and repeat settings
+  * **Target stat(s)** (e.g., Strength, Creativity, Fatherhood)
+
+    * Tasks can optionally grant XP to one or more stats
+
+#### 2. **Track Progress**
+
+* Quests are visible on the **homepage dashboard** if active
+* For each quest:
+
+  * Show number of completed tasks vs total
+  * Progress bar for time remaining and completion %
+  * XP earned from tasks so far
+  * Show task list with checkboxes
+
+#### 3. **Complete Tasks**
+
+* Marking a task as complete:
+
+  * Grants optional XP to associated stat(s)
+  * Saves a timestamp
+
+#### 4. **Completion Logic**
+
+* Quests can be:
+
+  * **Active** (now until end date)
+  * **Expired** (end date passed, not fully complete)
+  * **Completed** (all tasks finished)
+* If all tasks are completed before the deadline:
+
+  * Bonus XP is awarded to the primary stat(s)
+  * GPT may generate a congratulatory journal summary (optional future)
+
+#### 5. **Delete / Archive Quests**
+
+* Deleting a quest **does not delete** tasks or journal entries associated with it
+* Quests can be archived after completion
+
+---
+
+### ✅ Acceptance Criteria
+
+* [ ] User can create a quest with multiple tasks
+* [ ] Quests are shown on the homepage while active
+* [ ] Task completion is tracked with XP gains
+* [ ] Quests display progress, time remaining, and XP earned
+* [ ] Quests can be completed, expired, or archived
+* [ ] Deleting a quest does not remove completed tasks or journal entries

--- a/copilot/followups/quest-analysis.md
+++ b/copilot/followups/quest-analysis.md
@@ -1,0 +1,73 @@
+### 📌 Issue: Quest Reflections (GPT-Based Summary & Analysis)
+
+**Goal**: After a quest ends, GPT analyzes the user’s journey — reviewing journal entries, task completions, tone tags, and XP changes — and generates a reflection that helps the user understand what they gained, what was hard, and what to focus on next.
+
+---
+
+### 🧩 Feature Requirements
+
+#### 1. **Trigger Reflection**
+
+* Triggered automatically when:
+
+  * A quest is marked **completed**
+  * OR the **end date passes**
+* Can also be triggered manually via a “Reflect on this Quest” button
+
+#### 2. **GPT Analysis Input**
+
+GPT receives:
+
+* The quest’s:
+
+  * Title
+  * Description
+  * Dates
+  * Tasks completed (with timestamps and associated XP/stat tags)
+* All **journal entries** made during the quest window
+
+  * Includes content tags, tone tags, and stat tags
+* Optional user notes or manual input (future feature)
+
+#### 3. **GPT Output**
+
+GPT returns a reflection including:
+
+* **Reflection Summary**: A 3–5 sentence summary of what happened and how it went
+* **Growth Analysis**:
+
+  * What character stats improved (and why)
+  * Notable journal moments or emotional shifts
+  * Strengths demonstrated and areas of difficulty
+* **Forward Guidance**:
+
+  * Suggestions for what to do next
+  * Possible new quests or experiments to consider
+
+#### 4. **Display in Quest Page**
+
+* Reflections appear at the bottom of the quest’s dashboard view
+* Include ability to re-generate or edit
+* Reflections are timestamped and saved in the database
+
+---
+
+### ✨ Example GPT Output
+
+> **Reflection Summary:**
+> During your "Reconnect with Nature" quest, you completed 5 hikes and consistently reflected on how grounding the outdoors felt. You gained 40 XP in Strength and saw notable increases in Calm tone tags.
+
+> **Growth Analysis:**
+> You showed consistency and resilience despite poor weather. Your journal entries revealed a transition from anxious to more centered. The most meaningful moment seemed to be your hike with your son.
+
+> **Next Steps:**
+> Consider a follow-up quest like "Sunrise Walks" or an adventure with more family involvement. You might also journal about how nature supports your parenting and mental clarity.
+
+---
+
+### ✅ Acceptance Criteria
+
+* [ ] GPT can analyze quests based on tasks and journals within the date range
+* [ ] Reflection includes summary, growth insights, and forward guidance
+* [ ] Reflection is saved and shown on the quest page
+* [ ] Reflection can be re-generated or edited


### PR DESCRIPTION
Implement backend support for quests, enabling users to create, track, and complete structured challenges. This includes validation schemas, types, and database integration for quests and their associated tasks.