### PR TITLE
Support simple todos

### DIFF
--- a/backend/src/db/migrations/0012_flaky_molten_man.sql
+++ b/backend/src/db/migrations/0012_flaky_molten_man.sql
@@ -1,0 +1,11 @@
+CREATE TABLE "simple_todos" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"description" varchar(500) NOT NULL,
+	"is_completed" boolean DEFAULT false NOT NULL,
+	"completed_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "simple_todos" ADD CONSTRAINT "simple_todos_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;

--- a/backend/src/db/migrations/meta/0012_snapshot.json
+++ b/backend/src/db/migrations/meta/0012_snapshot.json
@@ -1,0 +1,1316 @@
+{
+  "id": "1b1e5cf8-1109-4587-be7b-f7a4d293bd40",
+  "prevId": "097e9944-beab-4516-b845-7166b7f758be",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.characters": {
+      "name": "characters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_class": {
+          "name": "character_class",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backstory": {
+          "name": "backstory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goals": {
+          "name": "goals",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "motto": {
+          "name": "motto",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "characters_user_id_users_id_fk": {
+          "name": "characters_user_id_users_id_fk",
+          "tableFrom": "characters",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.character_stat_level_titles": {
+      "name": "character_stat_level_titles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "stat_id": {
+          "name": "stat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "character_stat_level_titles_stat_id_character_stats_id_fk": {
+          "name": "character_stat_level_titles_stat_id_character_stats_id_fk",
+          "tableFrom": "character_stat_level_titles",
+          "tableTo": "character_stats",
+          "columnsFrom": [
+            "stat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.character_stat_xp_grants": {
+      "name": "character_stat_xp_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stat_id": {
+          "name": "stat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "xp_amount": {
+          "name": "xp_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "character_stat_xp_grants_user_id_users_id_fk": {
+          "name": "character_stat_xp_grants_user_id_users_id_fk",
+          "tableFrom": "character_stat_xp_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "character_stat_xp_grants_stat_id_character_stats_id_fk": {
+          "name": "character_stat_xp_grants_stat_id_character_stats_id_fk",
+          "tableFrom": "character_stat_xp_grants",
+          "tableTo": "character_stats",
+          "columnsFrom": [
+            "stat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.character_stats": {
+      "name": "character_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "example_activities": {
+          "name": "example_activities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "current_level": {
+          "name": "current_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "total_xp": {
+          "name": "total_xp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "character_stats_user_id_users_id_fk": {
+          "name": "character_stats_user_id_users_id_fk",
+          "tableFrom": "character_stats",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.goals": {
+      "name": "goals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "goals_user_id_users_id_fk": {
+          "name": "goals_user_id_users_id_fk",
+          "tableFrom": "goals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.family_members": {
+      "name": "family_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relationship": {
+          "name": "relationship",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birthday": {
+          "name": "birthday",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "likes": {
+          "name": "likes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dislikes": {
+          "name": "dislikes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "energy_level": {
+          "name": "energy_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 50
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_interaction_date": {
+          "name": "last_interaction_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection_xp": {
+          "name": "connection_xp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "connection_level": {
+          "name": "connection_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "family_members_user_id_users_id_fk": {
+          "name": "family_members_user_id_users_id_fk",
+          "tableFrom": "family_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.family_task_feedback": {
+      "name": "family_task_feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "family_member_id": {
+          "name": "family_member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_description": {
+          "name": "task_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enjoyed_it": {
+          "name": "enjoyed_it",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "xp_granted": {
+          "name": "xp_granted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "family_task_feedback_user_id_users_id_fk": {
+          "name": "family_task_feedback_user_id_users_id_fk",
+          "tableFrom": "family_task_feedback",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "family_task_feedback_family_member_id_family_members_id_fk": {
+          "name": "family_task_feedback_family_member_id_family_members_id_fk",
+          "tableFrom": "family_task_feedback",
+          "tableTo": "family_members",
+          "columnsFrom": [
+            "family_member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.goal_tags": {
+      "name": "goal_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "goal_id": {
+          "name": "goal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "goal_tags_goal_id_goals_id_fk": {
+          "name": "goal_tags_goal_id_goals_id_fk",
+          "tableFrom": "goal_tags",
+          "tableTo": "goals",
+          "columnsFrom": [
+            "goal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "goal_tags_tag_id_tags_id_fk": {
+          "name": "goal_tags_tag_id_tags_id_fk",
+          "tableFrom": "goal_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tags_user_id_users_id_fk": {
+          "name": "tags_user_id_users_id_fk",
+          "tableFrom": "tags",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_tag": {
+          "name": "unique_user_tag",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.focuses": {
+      "name": "focuses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "focuses_user_id_users_id_fk": {
+          "name": "focuses_user_id_users_id_fk",
+          "tableFrom": "focuses",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.journal_conversation_messages": {
+      "name": "journal_conversation_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_order": {
+          "name": "message_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "journal_conversation_messages_entry_id_journal_entries_id_fk": {
+          "name": "journal_conversation_messages_entry_id_journal_entries_id_fk",
+          "tableFrom": "journal_conversation_messages",
+          "tableTo": "journal_entries",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.journal_entries": {
+      "name": "journal_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synopsis": {
+          "name": "synopsis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "journal_entries_user_id_users_id_fk": {
+          "name": "journal_entries_user_id_users_id_fk",
+          "tableFrom": "journal_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.journal_entry_stat_tags": {
+      "name": "journal_entry_stat_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stat_id": {
+          "name": "stat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "journal_entry_stat_tags_entry_id_journal_entries_id_fk": {
+          "name": "journal_entry_stat_tags_entry_id_journal_entries_id_fk",
+          "tableFrom": "journal_entry_stat_tags",
+          "tableTo": "journal_entries",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "journal_entry_stat_tags_stat_id_character_stats_id_fk": {
+          "name": "journal_entry_stat_tags_stat_id_character_stats_id_fk",
+          "tableFrom": "journal_entry_stat_tags",
+          "tableTo": "character_stats",
+          "columnsFrom": [
+            "stat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.journal_entry_tags": {
+      "name": "journal_entry_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "journal_entry_tags_entry_id_journal_entries_id_fk": {
+          "name": "journal_entry_tags_entry_id_journal_entries_id_fk",
+          "tableFrom": "journal_entry_tags",
+          "tableTo": "journal_entries",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "journal_entry_tags_tag_id_tags_id_fk": {
+          "name": "journal_entry_tags_tag_id_tags_id_fk",
+          "tableFrom": "journal_entry_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.journal_sessions": {
+      "name": "journal_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messages": {
+          "name": "messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'true'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "journal_sessions_user_id_users_id_fk": {
+          "name": "journal_sessions_user_id_users_id_fk",
+          "tableFrom": "journal_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simple_todos": {
+      "name": "simple_todos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_completed": {
+          "name": "is_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "simple_todos_user_id_users_id_fk": {
+          "name": "simple_todos_user_id_users_id_fk",
+          "tableFrom": "simple_todos",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/src/db/migrations/meta/_journal.json
+++ b/backend/src/db/migrations/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1752201519817,
       "tag": "0011_harsh_molten_man",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1752205696619,
+      "tag": "0012_flaky_molten_man",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -7,6 +7,7 @@ export { createGoalSchema, updateGoalSchema } from '../validation/goals';
 export { createFamilyMemberSchema, updateFamilyMemberSchema, createFamilyTaskFeedbackSchema } from '../validation/family';
 export { createFocusSchema, updateFocusSchema, batchUpdateFocusesSchema } from '../validation/focus';
 export { startJournalSessionSchema, sendJournalMessageSchema, saveJournalEntrySchema, getJournalEntrySchema } from '../validation/journal';
+export { createSimpleTodoSchema, updateSimpleTodoSchema, completeSimpleTodoSchema } from '../validation/todos';
 
 // Re-export types for backward compatibility
 export type { User, NewUser, PublicUser } from '../types/users';
@@ -40,3 +41,11 @@ export type {
   JournalEntryWithDetails,
   ChatMessage,
 } from '../types/journal';
+export type {
+  SimpleTodo,
+  NewSimpleTodo,
+  UpdateSimpleTodo,
+  CreateSimpleTodoRequest,
+  UpdateSimpleTodoRequest,
+  SimpleTodoResponse,
+} from '../types/todos';

--- a/backend/src/db/schema/index.ts
+++ b/backend/src/db/schema/index.ts
@@ -7,6 +7,7 @@ export * from './family';
 export * from './tags';
 export * from './focus';
 export * from './journal';
+export * from './todos';
 // Future exports:
 // export * from './posts';
 // export * from './comments';

--- a/backend/src/db/schema/todos.ts
+++ b/backend/src/db/schema/todos.ts
@@ -1,0 +1,15 @@
+import { pgTable, uuid, varchar, boolean, timestamp } from 'drizzle-orm/pg-core';
+import { users } from './users';
+
+// Simple todos table - lightweight one-off tasks for the homepage
+export const simpleTodos = pgTable('simple_todos', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  userId: uuid('user_id')
+    .notNull()
+    .references(() => users.id, { onDelete: 'cascade' }),
+  description: varchar('description', { length: 500 }).notNull(),
+  isCompleted: boolean('is_completed').default(false).notNull(),
+  completedAt: timestamp('completed_at', { withTimezone: true }),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+});

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -10,6 +10,7 @@ import familyRoutes from './routes/family';
 import tagsRoutes from './routes/tags';
 import focusRoutes from './routes/focus';
 import journalRoutes from './routes/journal';
+import todosRoutes from './routes/todos';
 
 // Create main app instance
 const app = new Hono();
@@ -55,7 +56,9 @@ const routes = app
   // Mount focus routes
   .route('/api/focus', focusRoutes)
   // Mount journal routes
-  .route('/api/journal', journalRoutes);
+  .route('/api/journal', journalRoutes)
+  // Mount todos routes
+  .route('/api/todos', todosRoutes);
 
 // Serve static files - but exclude API routes using a custom condition
 app.use('*', async (c, next) => {

--- a/backend/src/routes/todos.ts
+++ b/backend/src/routes/todos.ts
@@ -1,0 +1,253 @@
+import { Hono } from 'hono';
+import { zValidator } from '@hono/zod-validator';
+import { eq, and, desc } from 'drizzle-orm';
+import { jwtAuth, getUserId } from '../middleware/auth';
+import { db } from '../db';
+import { simpleTodos } from '../db/schema/todos';
+import { createSimpleTodoSchema, updateSimpleTodoSchema, completeSimpleTodoSchema } from '../validation/todos';
+import { handleApiError } from '../utils/logger';
+import type { SimpleTodoResponse } from '../types/todos';
+
+const app = new Hono()
+  // Get user's simple todos (only active/incomplete ones by default)
+  .get('/', jwtAuth, async (c) => {
+    try {
+      const userId = getUserId(c);
+
+      const todos = await db
+        .select({
+          id: simpleTodos.id,
+          description: simpleTodos.description,
+          isCompleted: simpleTodos.isCompleted,
+          completedAt: simpleTodos.completedAt,
+          createdAt: simpleTodos.createdAt,
+          updatedAt: simpleTodos.updatedAt,
+        })
+        .from(simpleTodos)
+        .where(and(eq(simpleTodos.userId, userId), eq(simpleTodos.isCompleted, false)))
+        .orderBy(desc(simpleTodos.createdAt));
+
+      const formattedTodos: SimpleTodoResponse[] = todos.map((todo) => ({
+        id: todo.id,
+        description: todo.description,
+        isCompleted: todo.isCompleted,
+        completedAt: todo.completedAt?.toISOString() || null,
+        createdAt: todo.createdAt.toISOString(),
+        updatedAt: todo.updatedAt.toISOString(),
+      }));
+
+      return c.json({
+        success: true,
+        data: formattedTodos,
+      });
+    } catch (error) {
+      return handleApiError(error, 'Failed to fetch simple todos');
+    }
+  })
+
+  // Create a new simple todo
+  .post('/', jwtAuth, zValidator('json', createSimpleTodoSchema), async (c) => {
+    try {
+      const userId = getUserId(c);
+      const data = c.req.valid('json');
+
+      const [newTodo] = await db
+        .insert(simpleTodos)
+        .values({
+          userId,
+          description: data.description,
+        })
+        .returning({
+          id: simpleTodos.id,
+          description: simpleTodos.description,
+          isCompleted: simpleTodos.isCompleted,
+          completedAt: simpleTodos.completedAt,
+          createdAt: simpleTodos.createdAt,
+          updatedAt: simpleTodos.updatedAt,
+        });
+
+      const formattedTodo: SimpleTodoResponse = {
+        id: newTodo.id,
+        description: newTodo.description,
+        isCompleted: newTodo.isCompleted,
+        completedAt: newTodo.completedAt?.toISOString() || null,
+        createdAt: newTodo.createdAt.toISOString(),
+        updatedAt: newTodo.updatedAt.toISOString(),
+      };
+
+      return c.json(
+        {
+          success: true,
+          data: formattedTodo,
+        },
+        201,
+      );
+    } catch (error) {
+      return handleApiError(error, 'Failed to create simple todo');
+    }
+  })
+
+  // Update a simple todo
+  .put('/:id', jwtAuth, zValidator('json', updateSimpleTodoSchema), async (c) => {
+    try {
+      const userId = getUserId(c);
+      const todoId = c.req.param('id');
+      const data = c.req.valid('json');
+
+      // Check if todo exists and belongs to the user
+      const existingTodo = await db
+        .select()
+        .from(simpleTodos)
+        .where(and(eq(simpleTodos.id, todoId), eq(simpleTodos.userId, userId)))
+        .limit(1);
+
+      if (existingTodo.length === 0) {
+        return c.json(
+          {
+            success: false,
+            error: 'Simple todo not found',
+          },
+          404,
+        );
+      }
+
+      const updateData: any = {
+        updatedAt: new Date(),
+      };
+
+      // Only update provided fields
+      if (data.description !== undefined) {
+        updateData.description = data.description;
+      }
+
+      if (data.isCompleted !== undefined) {
+        updateData.isCompleted = data.isCompleted;
+        // Set or clear completedAt based on completion status
+        updateData.completedAt = data.isCompleted ? new Date() : null;
+      }
+
+      const [updatedTodo] = await db
+        .update(simpleTodos)
+        .set(updateData)
+        .where(eq(simpleTodos.id, todoId))
+        .returning({
+          id: simpleTodos.id,
+          description: simpleTodos.description,
+          isCompleted: simpleTodos.isCompleted,
+          completedAt: simpleTodos.completedAt,
+          createdAt: simpleTodos.createdAt,
+          updatedAt: simpleTodos.updatedAt,
+        });
+
+      const formattedTodo: SimpleTodoResponse = {
+        id: updatedTodo.id,
+        description: updatedTodo.description,
+        isCompleted: updatedTodo.isCompleted,
+        completedAt: updatedTodo.completedAt?.toISOString() || null,
+        createdAt: updatedTodo.createdAt.toISOString(),
+        updatedAt: updatedTodo.updatedAt.toISOString(),
+      };
+
+      return c.json({
+        success: true,
+        data: formattedTodo,
+      });
+    } catch (error) {
+      return handleApiError(error, 'Failed to update simple todo');
+    }
+  })
+
+  // Complete/uncomplete a simple todo (convenience endpoint)
+  .patch('/:id/complete', jwtAuth, zValidator('json', completeSimpleTodoSchema), async (c) => {
+    try {
+      const userId = getUserId(c);
+      const todoId = c.req.param('id');
+      const data = c.req.valid('json');
+
+      // Check if todo exists and belongs to the user
+      const existingTodo = await db
+        .select()
+        .from(simpleTodos)
+        .where(and(eq(simpleTodos.id, todoId), eq(simpleTodos.userId, userId)))
+        .limit(1);
+
+      if (existingTodo.length === 0) {
+        return c.json(
+          {
+            success: false,
+            error: 'Simple todo not found',
+          },
+          404,
+        );
+      }
+
+      const [updatedTodo] = await db
+        .update(simpleTodos)
+        .set({
+          isCompleted: data.isCompleted,
+          completedAt: data.isCompleted ? new Date() : null,
+          updatedAt: new Date(),
+        })
+        .where(eq(simpleTodos.id, todoId))
+        .returning({
+          id: simpleTodos.id,
+          description: simpleTodos.description,
+          isCompleted: simpleTodos.isCompleted,
+          completedAt: simpleTodos.completedAt,
+          createdAt: simpleTodos.createdAt,
+          updatedAt: simpleTodos.updatedAt,
+        });
+
+      const formattedTodo: SimpleTodoResponse = {
+        id: updatedTodo.id,
+        description: updatedTodo.description,
+        isCompleted: updatedTodo.isCompleted,
+        completedAt: updatedTodo.completedAt?.toISOString() || null,
+        createdAt: updatedTodo.createdAt.toISOString(),
+        updatedAt: updatedTodo.updatedAt.toISOString(),
+      };
+
+      return c.json({
+        success: true,
+        data: formattedTodo,
+      });
+    } catch (error) {
+      return handleApiError(error, 'Failed to complete simple todo');
+    }
+  })
+
+  // Delete a simple todo
+  .delete('/:id', jwtAuth, async (c) => {
+    try {
+      const userId = getUserId(c);
+      const todoId = c.req.param('id');
+
+      // Check if todo exists and belongs to the user
+      const existingTodo = await db
+        .select()
+        .from(simpleTodos)
+        .where(and(eq(simpleTodos.id, todoId), eq(simpleTodos.userId, userId)))
+        .limit(1);
+
+      if (existingTodo.length === 0) {
+        return c.json(
+          {
+            success: false,
+            error: 'Simple todo not found',
+          },
+          404,
+        );
+      }
+
+      await db.delete(simpleTodos).where(eq(simpleTodos.id, todoId));
+
+      return c.json({
+        success: true,
+        data: { id: todoId },
+      });
+    } catch (error) {
+      return handleApiError(error, 'Failed to delete simple todo');
+    }
+  });
+
+export default app;

--- a/backend/src/tests/setup.ts
+++ b/backend/src/tests/setup.ts
@@ -60,6 +60,8 @@ export async function cleanDatabase() {
     await safeDelete(schema.characterStats, 'character_stats');
     await safeDelete(schema.goals, 'goals');
     await safeDelete(schema.characters, 'characters');
+    // Simple todos (reference users)
+    await safeDelete(schema.simpleTodos, 'simple_todos');
     await safeDelete(schema.users, 'users');
   } catch (error) {
     if (error instanceof Error && !error.message.includes('CONNECTION_ENDED')) {

--- a/backend/src/tests/todos.test.ts
+++ b/backend/src/tests/todos.test.ts
@@ -1,0 +1,527 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import appExport from '../index';
+import { testDb, cleanDatabase, schema } from './setup';
+import { eq } from 'drizzle-orm';
+
+// Create wrapper to maintain compatibility with test expectations
+const app = {
+  request: (url: string, init?: RequestInit) => {
+    const absoluteUrl = url.startsWith('http') ? url : `http://localhost${url}`;
+    return appExport.fetch(new Request(absoluteUrl, init));
+  },
+};
+
+describe('Simple Todos API Integration Tests', () => {
+  let authToken: string;
+  let userId: string;
+
+  beforeEach(async () => {
+    await cleanDatabase();
+
+    // Create a test user with unique email and get auth token for protected routes
+    const testId = Date.now() + Math.random();
+    const userData = {
+      name: 'Test User',
+      email: `test${testId}@example.com`,
+      password: 'testpassword123',
+    };
+
+    const signupRes = await app.request('/api/users', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(userData),
+    });
+
+    const signupData = await signupRes.json();
+    authToken = signupData.token;
+    userId = signupData.user.id;
+  });
+
+  describe('GET /api/todos', () => {
+    it('should return empty array when user has no todos', async () => {
+      const res = await app.request('/api/todos', {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${authToken}`,
+        },
+      });
+
+      expect(res.status).toBe(200);
+      const responseData = await res.json();
+      expect(responseData.success).toBe(true);
+      expect(responseData.data).toEqual([]);
+    });
+
+    it('should return only incomplete todos', async () => {
+      const db = testDb();
+      
+      // Create some todos directly in database
+      await db.insert(schema.simpleTodos).values([
+        {
+          userId,
+          description: 'Incomplete todo',
+          isCompleted: false,
+        },
+        {
+          userId,
+          description: 'Completed todo',
+          isCompleted: true,
+          completedAt: new Date(),
+        },
+      ]);
+
+      const res = await app.request('/api/todos', {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${authToken}`,
+        },
+      });
+
+      expect(res.status).toBe(200);
+      const responseData = await res.json();
+      expect(responseData.success).toBe(true);
+      expect(responseData.data).toHaveLength(1);
+      expect(responseData.data[0].description).toBe('Incomplete todo');
+      expect(responseData.data[0].isCompleted).toBe(false);
+    });
+
+    it('should require authentication', async () => {
+      const res = await app.request('/api/todos', {
+        method: 'GET',
+      });
+
+      expect(res.status).toBe(401);
+    });
+
+    it('should only return todos for the authenticated user', async () => {
+      const db = testDb();
+
+      // Create another user
+      const anotherUser = await db.insert(schema.users).values({
+        name: 'Another User',
+        email: 'another@example.com',
+        password: 'password',
+      }).returning();
+
+      // Create todos for both users
+      await db.insert(schema.simpleTodos).values([
+        {
+          userId,
+          description: 'My todo',
+          isCompleted: false,
+        },
+        {
+          userId: anotherUser[0].id,
+          description: 'Other user todo',
+          isCompleted: false,
+        },
+      ]);
+
+      const res = await app.request('/api/todos', {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${authToken}`,
+        },
+      });
+
+      expect(res.status).toBe(200);
+      const responseData = await res.json();
+      expect(responseData.success).toBe(true);
+      expect(responseData.data).toHaveLength(1);
+      expect(responseData.data[0].description).toBe('My todo');
+    });
+  });
+
+  describe('POST /api/todos', () => {
+    it('should create a new simple todo', async () => {
+      const todoData = {
+        description: 'Buy groceries',
+      };
+
+      const res = await app.request('/api/todos', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${authToken}`,
+        },
+        body: JSON.stringify(todoData),
+      });
+
+      expect(res.status).toBe(201);
+      const responseData = await res.json();
+
+      expect(responseData.success).toBe(true);
+      expect(responseData.data).toMatchObject({
+        description: todoData.description,
+        isCompleted: false,
+        completedAt: null,
+      });
+      expect(responseData.data).toHaveProperty('id');
+      expect(responseData.data).toHaveProperty('createdAt');
+      expect(responseData.data).toHaveProperty('updatedAt');
+
+      // Verify todo was actually created in database
+      const db = testDb();
+      const dbTodo = await db.select().from(schema.simpleTodos).where(eq(schema.simpleTodos.id, responseData.data.id)).limit(1);
+
+      expect(dbTodo).toHaveLength(1);
+      expect(dbTodo[0].description).toBe(todoData.description);
+      expect(dbTodo[0].userId).toBe(userId);
+      expect(dbTodo[0].isCompleted).toBe(false);
+    });
+
+    it('should require authentication', async () => {
+      const todoData = {
+        description: 'Buy groceries',
+      };
+
+      const res = await app.request('/api/todos', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(todoData),
+      });
+
+      expect(res.status).toBe(401);
+    });
+
+    it('should validate required fields', async () => {
+      const res = await app.request('/api/todos', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${authToken}`,
+        },
+        body: JSON.stringify({}),
+      });
+
+      expect(res.status).toBe(400);
+    });
+
+    it('should validate description length', async () => {
+      const todoData = {
+        description: 'x'.repeat(501), // Too long
+      };
+
+      const res = await app.request('/api/todos', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${authToken}`,
+        },
+        body: JSON.stringify(todoData),
+      });
+
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('PUT /api/todos/:id', () => {
+    let todoId: string;
+
+    beforeEach(async () => {
+      // Create a test todo
+      const res = await app.request('/api/todos', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${authToken}`,
+        },
+        body: JSON.stringify({
+          description: 'Original description',
+        }),
+      });
+      const responseData = await res.json();
+      todoId = responseData.data.id;
+    });
+
+    it('should update todo description', async () => {
+      const updateData = {
+        description: 'Updated description',
+      };
+
+      const res = await app.request(`/api/todos/${todoId}`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${authToken}`,
+        },
+        body: JSON.stringify(updateData),
+      });
+
+      expect(res.status).toBe(200);
+      const responseData = await res.json();
+
+      expect(responseData.success).toBe(true);
+      expect(responseData.data).toMatchObject({
+        id: todoId,
+        description: updateData.description,
+        isCompleted: false,
+      });
+
+      // Verify in database
+      const db = testDb();
+      const dbTodo = await db.select().from(schema.simpleTodos).where(eq(schema.simpleTodos.id, todoId)).limit(1);
+
+      expect(dbTodo[0].description).toBe(updateData.description);
+    });
+
+    it('should update completion status', async () => {
+      const updateData = {
+        isCompleted: true,
+      };
+
+      const res = await app.request(`/api/todos/${todoId}`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${authToken}`,
+        },
+        body: JSON.stringify(updateData),
+      });
+
+      expect(res.status).toBe(200);
+      const responseData = await res.json();
+
+      expect(responseData.success).toBe(true);
+      expect(responseData.data).toMatchObject({
+        id: todoId,
+        isCompleted: true,
+      });
+      expect(responseData.data.completedAt).not.toBeNull();
+
+      // Verify in database
+      const db = testDb();
+      const dbTodo = await db.select().from(schema.simpleTodos).where(eq(schema.simpleTodos.id, todoId)).limit(1);
+
+      expect(dbTodo[0].isCompleted).toBe(true);
+      expect(dbTodo[0].completedAt).not.toBeNull();
+    });
+
+    it('should allow partial updates', async () => {
+      const updateData = {
+        description: 'Partially updated',
+      };
+
+      const res = await app.request(`/api/todos/${todoId}`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${authToken}`,
+        },
+        body: JSON.stringify(updateData),
+      });
+
+      expect(res.status).toBe(200);
+      const responseData = await res.json();
+
+      expect(responseData.success).toBe(true);
+      expect(responseData.data).toMatchObject({
+        id: todoId,
+        description: updateData.description,
+        isCompleted: false, // Should remain unchanged
+      });
+    });
+
+    it('should return 404 for non-existent todo', async () => {
+      const nonExistentId = '550e8400-e29b-41d4-a716-446655440000';
+
+      const res = await app.request(`/api/todos/${nonExistentId}`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${authToken}`,
+        },
+        body: JSON.stringify({
+          description: 'Updated',
+        }),
+      });
+
+      expect(res.status).toBe(404);
+    });
+
+    it('should not allow updating other users todos', async () => {
+      const db = testDb();
+
+      // Create another user and their todo
+      const anotherUser = await db.insert(schema.users).values({
+        name: 'Another User',
+        email: 'another@example.com',
+        password: 'password',
+      }).returning();
+
+      const anotherTodo = await db.insert(schema.simpleTodos).values({
+        userId: anotherUser[0].id,
+        description: 'Other user todo',
+      }).returning();
+
+      const res = await app.request(`/api/todos/${anotherTodo[0].id}`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${authToken}`,
+        },
+        body: JSON.stringify({
+          description: 'Trying to update',
+        }),
+      });
+
+      expect(res.status).toBe(404); // Should be treated as not found
+    });
+  });
+
+  describe('PATCH /api/todos/:id/complete', () => {
+    let todoId: string;
+
+    beforeEach(async () => {
+      // Create a test todo
+      const res = await app.request('/api/todos', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${authToken}`,
+        },
+        body: JSON.stringify({
+          description: 'Test todo',
+        }),
+      });
+      const responseData = await res.json();
+      todoId = responseData.data.id;
+    });
+
+    it('should mark todo as completed', async () => {
+      const res = await app.request(`/api/todos/${todoId}/complete`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${authToken}`,
+        },
+        body: JSON.stringify({
+          isCompleted: true,
+        }),
+      });
+
+      expect(res.status).toBe(200);
+      const responseData = await res.json();
+
+      expect(responseData.success).toBe(true);
+      expect(responseData.data.isCompleted).toBe(true);
+      expect(responseData.data.completedAt).not.toBeNull();
+    });
+
+    it('should mark todo as incomplete', async () => {
+      // First complete it
+      await app.request(`/api/todos/${todoId}/complete`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${authToken}`,
+        },
+        body: JSON.stringify({
+          isCompleted: true,
+        }),
+      });
+
+      // Then mark as incomplete
+      const res = await app.request(`/api/todos/${todoId}/complete`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${authToken}`,
+        },
+        body: JSON.stringify({
+          isCompleted: false,
+        }),
+      });
+
+      expect(res.status).toBe(200);
+      const responseData = await res.json();
+
+      expect(responseData.success).toBe(true);
+      expect(responseData.data.isCompleted).toBe(false);
+      expect(responseData.data.completedAt).toBeNull();
+    });
+  });
+
+  describe('DELETE /api/todos/:id', () => {
+    let todoId: string;
+
+    beforeEach(async () => {
+      // Create a test todo
+      const res = await app.request('/api/todos', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${authToken}`,
+        },
+        body: JSON.stringify({
+          description: 'Todo to delete',
+        }),
+      });
+      const responseData = await res.json();
+      todoId = responseData.data.id;
+    });
+
+    it('should delete todo', async () => {
+      const res = await app.request(`/api/todos/${todoId}`, {
+        method: 'DELETE',
+        headers: {
+          Authorization: `Bearer ${authToken}`,
+        },
+      });
+
+      expect(res.status).toBe(200);
+      const responseData = await res.json();
+
+      expect(responseData.success).toBe(true);
+      expect(responseData.data.id).toBe(todoId);
+
+      // Verify todo was deleted from database
+      const db = testDb();
+      const dbTodos = await db.select().from(schema.simpleTodos).where(eq(schema.simpleTodos.id, todoId));
+
+      expect(dbTodos).toHaveLength(0);
+    });
+
+    it('should return 404 for non-existent todo', async () => {
+      const nonExistentId = '550e8400-e29b-41d4-a716-446655440000';
+
+      const res = await app.request(`/api/todos/${nonExistentId}`, {
+        method: 'DELETE',
+        headers: {
+          Authorization: `Bearer ${authToken}`,
+        },
+      });
+
+      expect(res.status).toBe(404);
+    });
+
+    it('should not allow deleting other users todos', async () => {
+      const db = testDb();
+
+      // Create another user and their todo
+      const anotherUser = await db.insert(schema.users).values({
+        name: 'Another User',
+        email: 'another@example.com',
+        password: 'password',
+      }).returning();
+
+      const anotherTodo = await db.insert(schema.simpleTodos).values({
+        userId: anotherUser[0].id,
+        description: 'Other user todo',
+      }).returning();
+
+      const res = await app.request(`/api/todos/${anotherTodo[0].id}`, {
+        method: 'DELETE',
+        headers: {
+          Authorization: `Bearer ${authToken}`,
+        },
+      });
+
+      expect(res.status).toBe(404); // Should be treated as not found
+    });
+  });
+});

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -5,6 +5,7 @@ export * from './goals';
 export * from './family';
 export * from './tags';
 export * from './focus';
+export * from './todos';
 // Future exports:
 // export * from './posts';
 // export * from './auth';

--- a/backend/src/types/todos.ts
+++ b/backend/src/types/todos.ts
@@ -1,0 +1,25 @@
+import type { InferSelectModel, InferInsertModel } from 'drizzle-orm';
+import { simpleTodos } from '../db/schema/todos';
+
+export type SimpleTodo = InferSelectModel<typeof simpleTodos>;
+export type NewSimpleTodo = InferInsertModel<typeof simpleTodos>;
+export type UpdateSimpleTodo = Partial<Omit<NewSimpleTodo, 'id' | 'userId' | 'createdAt' | 'updatedAt'>>;
+
+// Request/Response types for API
+export type CreateSimpleTodoRequest = {
+  description: string;
+};
+
+export type UpdateSimpleTodoRequest = {
+  description?: string;
+  isCompleted?: boolean;
+};
+
+export type SimpleTodoResponse = {
+  id: string;
+  description: string;
+  isCompleted: boolean;
+  completedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+};

--- a/backend/src/validation/todos.ts
+++ b/backend/src/validation/todos.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+
+export const createSimpleTodoSchema = z.object({
+  description: z.string().min(1, 'Description is required').max(500, 'Description must be 500 characters or less'),
+});
+
+export const updateSimpleTodoSchema = z.object({
+  description: z.string().min(1, 'Description is required').max(500, 'Description must be 500 characters or less').optional(),
+  isCompleted: z.boolean().optional(),
+});
+
+export const completeSimpleTodoSchema = z.object({
+  isCompleted: z.boolean(),
+});

--- a/copilot/features/simple-todo.md
+++ b/copilot/features/simple-todo.md
@@ -1,0 +1,22 @@
+### ✅ Feature: Simple Todos
+
+**Description:**
+Allow users to create, view, and complete simple, one-off todo items. These are not tied to quests, experiments, or GPT context — they’re purely personal reminders. Simple todos are shown **only on the homepage** as a lightweight productivity aid.
+
+---
+
+**Acceptance Criteria:**
+
+* [ ] User can create a new simple todo with a short description
+* [ ] User can view a list of current simple todos on the homepage
+* [ ] User can mark a todo as complete
+* [ ] Completed todos are removed from the list (or optionally archived for now)
+* [ ] Todos are stored per-user
+
+---
+
+**Design Notes:**
+
+* Keep the interface minimal and frictionless
+* These items do **not** contribute XP
+* These todos should **not** appear in GPT task generation context

--- a/copilot/roadmap.md
+++ b/copilot/roadmap.md
@@ -39,11 +39,11 @@
 
 ### 🧠 Phase 2: GPT + Journal Integration (Weeks 3–4)
 
-- [ ] **Journal System**
+- [x] **Journal System**
   - Freeform conversational journal
   - Save entry after session
 
-- [ ] **GPT Journal Analysis**
+- [x] **GPT Journal Analysis**
   - Extract summary, synopsis, title
   - Assign content tags, tone tags, stat tags (and grant XP)
   - Store GPT log + metadata per entry

--- a/copilot/tasks-prd-gamified-life-app.md
+++ b/copilot/tasks-prd-gamified-life-app.md
@@ -34,9 +34,9 @@
   - [ ] 4.5 Ensure all goals/family tests pass
 
 - [ ] 5.0 Simple Todos (One-off Tasks)
-  - [ ] 5.1 Design and implement simple todo CRUD (backend)
-  - [ ] 5.2 Write backend integration tests for todos
-  - [ ] 5.3 Implement frontend UI for simple todos
+  - [x] 5.1 Design and implement simple todo CRUD (backend)
+  - [x] 5.2 Write backend integration tests for todos
+  - [x] 5.3 Implement frontend UI for simple todos
   - [ ] 5.4 Write frontend E2E tests for todos
   - [ ] 5.5 Ensure all todo tests pass
 

--- a/frontend/src/lib/api/todos.ts
+++ b/frontend/src/lib/api/todos.ts
@@ -1,0 +1,149 @@
+import { createAuthenticatedFetch } from '../api';
+import type {
+  SimpleTodoResponse,
+  CreateSimpleTodoRequest,
+  UpdateSimpleTodoRequest,
+} from '../../../.svelte-kit/backend-types/types/todos';
+
+interface ApiResponse<T> {
+  success: boolean;
+  data: T;
+}
+
+interface ApiError {
+  success: false;
+  error: string;
+}
+
+class SimpleTodosApi {
+  // Get all incomplete simple todos for the user
+  async getTodos(): Promise<SimpleTodoResponse[]> {
+    try {
+      const authenticatedFetch = createAuthenticatedFetch();
+      const response = await authenticatedFetch('/api/todos', {
+        method: 'GET',
+      });
+
+      if (!response.ok) {
+        console.error('Get todos API error:', response.status, response.statusText);
+        const result = await response.json().catch(() => ({ error: 'Unknown error' }));
+        throw new Error((result as any).error || `Error ${response.status}: ${response.statusText}`);
+      }
+
+      const result = (await response.json()) as ApiResponse<SimpleTodoResponse[]>;
+      return result.data;
+    } catch (error) {
+      console.error('Get todos API request failed:', error);
+      throw error;
+    }
+  }
+
+  // Create a new simple todo
+  async createTodo(data: CreateSimpleTodoRequest): Promise<SimpleTodoResponse> {
+    try {
+      const authenticatedFetch = createAuthenticatedFetch();
+      const response = await authenticatedFetch('/api/todos', {
+        method: 'POST',
+        body: JSON.stringify(data),
+      });
+
+      if (!response.ok) {
+        console.error('Create todo API error:', response.status, response.statusText);
+        const result = await response.json().catch(() => ({ error: 'Unknown error' }));
+
+        // Handle validation errors specifically
+        if (response.status === 400 && (result as any).error?.issues) {
+          const issues = (result as any).error.issues;
+          const messages = issues.map((issue: any) => issue.message).join(', ');
+          throw new Error(`Validation error: ${messages}`);
+        }
+
+        throw new Error((result as any).error || `Error ${response.status}: ${response.statusText}`);
+      }
+
+      const result = (await response.json()) as ApiResponse<SimpleTodoResponse>;
+      return result.data;
+    } catch (error) {
+      console.error('Create todo API request failed:', error);
+      throw error;
+    }
+  }
+
+  // Update a simple todo
+  async updateTodo(id: string, data: UpdateSimpleTodoRequest): Promise<SimpleTodoResponse> {
+    try {
+      const authenticatedFetch = createAuthenticatedFetch();
+      const response = await authenticatedFetch(`/api/todos/${id}`, {
+        method: 'PUT',
+        body: JSON.stringify(data),
+      });
+
+      if (!response.ok) {
+        console.error('Update todo API error:', response.status, response.statusText);
+        const result = await response.json().catch(() => ({ error: 'Unknown error' }));
+
+        // Handle validation errors specifically
+        if (response.status === 400 && (result as any).error?.issues) {
+          const issues = (result as any).error.issues;
+          const messages = issues.map((issue: any) => issue.message).join(', ');
+          throw new Error(`Validation error: ${messages}`);
+        }
+
+        throw new Error((result as any).error || `Error ${response.status}: ${response.statusText}`);
+      }
+
+      const result = (await response.json()) as ApiResponse<SimpleTodoResponse>;
+      return result.data;
+    } catch (error) {
+      console.error('Update todo API request failed:', error);
+      throw error;
+    }
+  }
+
+  // Mark a todo as complete/incomplete
+  async completeTodo(id: string, isCompleted: boolean): Promise<SimpleTodoResponse> {
+    try {
+      const authenticatedFetch = createAuthenticatedFetch();
+      const response = await authenticatedFetch(`/api/todos/${id}/complete`, {
+        method: 'PATCH',
+        body: JSON.stringify({ isCompleted }),
+      });
+
+      if (!response.ok) {
+        console.error('Complete todo API error:', response.status, response.statusText);
+        const result = await response.json().catch(() => ({ error: 'Unknown error' }));
+        throw new Error((result as any).error || `Error ${response.status}: ${response.statusText}`);
+      }
+
+      const result = (await response.json()) as ApiResponse<SimpleTodoResponse>;
+      return result.data;
+    } catch (error) {
+      console.error('Complete todo API request failed:', error);
+      throw error;
+    }
+  }
+
+  // Delete a simple todo
+  async deleteTodo(id: string): Promise<{ id: string }> {
+    try {
+      const authenticatedFetch = createAuthenticatedFetch();
+      const response = await authenticatedFetch(`/api/todos/${id}`, {
+        method: 'DELETE',
+      });
+
+      if (!response.ok) {
+        console.error('Delete todo API error:', response.status, response.statusText);
+        const result = await response.json().catch(() => ({ error: 'Unknown error' }));
+        throw new Error((result as any).error || `Error ${response.status}: ${response.statusText}`);
+      }
+
+      const result = (await response.json()) as ApiResponse<{ id: string }>;
+      return result.data;
+    } catch (error) {
+      console.error('Delete todo API request failed:', error);
+      throw error;
+    }
+  }
+}
+
+export const simpleTodosApi = new SimpleTodosApi();

--- a/frontend/src/lib/components/todos/SimpleTodosWidget.svelte
+++ b/frontend/src/lib/components/todos/SimpleTodosWidget.svelte
@@ -1,0 +1,259 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { simpleTodosStore } from '$lib/stores/todos';
+
+  let newTodoDescription = '';
+  let addingTodo = false;
+
+  // Reactive references to store state
+  $: ({ todos, loading, error } = $simpleTodosStore);
+  $: incompleteTodos = todos.filter(todo => !todo.isCompleted);
+  $: completedTodos = todos.filter(todo => todo.isCompleted);
+
+  onMount(() => {
+    simpleTodosStore.loadTodos();
+  });
+
+  async function addTodo() {
+    if (!newTodoDescription.trim() || addingTodo) return;
+    
+    addingTodo = true;
+    try {
+      await simpleTodosStore.createTodo(newTodoDescription.trim());
+      newTodoDescription = '';
+    } catch (err) {
+      console.error('Failed to add todo:', err);
+    } finally {
+      addingTodo = false;
+    }
+  }
+
+  async function toggleTodo(todoId: string, isCompleted: boolean) {
+    try {
+      await simpleTodosStore.completeTodo(todoId, isCompleted);
+    } catch (err) {
+      console.error('Failed to toggle todo:', err);
+    }
+  }
+
+  async function deleteTodo(todoId: string) {
+    try {
+      await simpleTodosStore.deleteTodo(todoId);
+    } catch (err) {
+      console.error('Failed to delete todo:', err);
+    }
+  }
+
+  function handleKeyPress(event: KeyboardEvent) {
+    if (event.key === 'Enter' && !event.shiftKey) {
+      event.preventDefault();
+      addTodo();
+    }
+  }
+</script>
+
+<div class="w-full">
+  <div class="mb-6 flex items-center gap-3">
+    <div class="text-accent">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="20"
+        height="20"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        <path d="M9 12l2 2 4-4" />
+        <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
+      </svg>
+    </div>
+    <h3 class="text-xl font-semibold">Quick Tasks</h3>
+  </div>
+
+  <!-- Add new todo form -->
+  <div class="mb-4">
+    <div class="flex gap-2">
+      <input
+        type="text"
+        placeholder="Add a quick task..."
+        class="input input-bordered flex-1 focus:input-accent transition-all duration-200"
+        bind:value={newTodoDescription}
+        on:keypress={handleKeyPress}
+        disabled={addingTodo}
+        maxlength="200"
+      />
+      <button
+        class="btn btn-accent btn-square transition-all duration-200 hover:scale-105"
+        on:click={addTodo}
+        disabled={addingTodo || !newTodoDescription.trim()}
+      >
+        {#if addingTodo}
+          <span class="loading loading-spinner loading-sm"></span>
+        {:else}
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <path d="M5 12h14" />
+            <path d="m12 5 7 7-7 7" />
+          </svg>
+        {/if}
+      </button>
+    </div>
+  </div>
+
+  <!-- Loading state -->
+  {#if loading && todos.length === 0}
+    <div class="flex justify-center py-4">
+      <span class="loading loading-spinner loading-md"></span>
+    </div>
+  {:else if error}
+    <!-- Error state -->
+    <div class="alert alert-error">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="16"
+        height="16"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        <circle cx="12" cy="12" r="10" />
+        <path d="M12 6v6" />
+        <path d="M12 16h.01" />
+      </svg>
+      <span class="text-sm">{error}</span>
+    </div>
+  {:else}
+    <!-- Todos list -->
+    <div class="space-y-3">
+      <!-- Incomplete todos -->
+      {#each incompleteTodos as todo (todo.id)}
+        <div class="flex items-center gap-3 rounded-lg bg-base-200/50 p-3 transition-all duration-200 hover:bg-base-200">
+          <input
+            type="checkbox"
+            class="checkbox checkbox-accent"
+            checked={false}
+            on:change={() => toggleTodo(todo.id, true)}
+          />
+          <span class="flex-1 text-sm">{todo.description}</span>
+          <button
+            class="btn btn-ghost btn-xs text-error hover:bg-error hover:text-error-content transition-all duration-200"
+            on:click={() => deleteTodo(todo.id)}
+            aria-label="Delete task"
+            title="Delete task"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <path d="M18 6 6 18" />
+              <path d="m6 6 12 12" />
+            </svg>
+          </button>
+        </div>
+      {/each}
+
+      <!-- Completed todos (show last 3) -->
+      {#if completedTodos.length > 0}
+        <div class="divider text-xs opacity-60">Recently Completed</div>
+        {#each completedTodos.slice(-3) as todo (todo.id)}
+          <div class="flex items-center gap-3 rounded-lg bg-base-200/30 p-3 opacity-60 transition-all duration-200">
+            <input
+              type="checkbox"
+              class="checkbox checkbox-accent"
+              checked={true}
+              on:change={() => toggleTodo(todo.id, false)}
+            />
+            <span class="flex-1 text-sm line-through">{todo.description}</span>
+            <button
+              class="btn btn-ghost btn-xs text-error hover:bg-error hover:text-error-content transition-all duration-200"
+              on:click={() => deleteTodo(todo.id)}
+              aria-label="Delete task"
+              title="Delete task"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path d="M18 6 6 18" />
+                <path d="m6 6 12 12" />
+              </svg>
+            </button>
+          </div>
+        {/each}
+      {/if}
+
+      <!-- Empty state -->
+      {#if incompleteTodos.length === 0 && completedTodos.length === 0}
+        <div class="flex flex-col items-center py-8 text-center">
+          <div class="text-accent mb-3 opacity-60">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="32"
+              height="32"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <path d="M9 12l2 2 4-4" />
+              <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
+            </svg>
+          </div>
+          <p class="text-sm text-base-content/60">No tasks yet. Add one above to get started!</p>
+        </div>
+      {:else if incompleteTodos.length === 0}
+        <div class="flex flex-col items-center py-6 text-center">
+          <div class="text-accent mb-3">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="28"
+              height="28"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <path d="m9 12 2 2 4-4" />
+              <path d="M21 12c.552 0 1.448-.063 1.448-.63 0-.567-.896-.63-1.448-.63-2.9 0-9.552 0-18 0-.552 0-1.448.063-1.448.63 0 .567.896.63 1.448.63 8.448 0 15.1 0 18 0Z"/>
+            </svg>
+          </div>
+          <p class="text-sm text-accent font-medium">All caught up! 🎉</p>
+          <p class="text-xs text-base-content/60 mt-1">Great job completing all your tasks</p>
+        </div>
+      {/if}
+    </div>
+  {/if}
+</div>

--- a/frontend/src/lib/stores/todos.ts
+++ b/frontend/src/lib/stores/todos.ts
@@ -1,0 +1,161 @@
+import { writable, derived } from 'svelte/store';
+import type { SimpleTodoResponse } from '../../../.svelte-kit/backend-types/types/todos';
+import { simpleTodosApi } from '../api/todos';
+
+// Types for the store
+interface SimpleTodosState {
+  todos: SimpleTodoResponse[];
+  loading: boolean;
+  error: string | null;
+}
+
+// Initial state
+const initialState: SimpleTodosState = {
+  todos: [],
+  loading: false,
+  error: null,
+};
+
+// Create the writable store
+const createSimpleTodosStore = () => {
+  const { subscribe, set, update } = writable<SimpleTodosState>(initialState);
+
+  return {
+    subscribe,
+
+    // Load todos from API
+    async loadTodos() {
+      update((state) => ({ ...state, loading: true, error: null }));
+      
+      try {
+        const todos = await simpleTodosApi.getTodos();
+        update((state) => ({ ...state, todos, loading: false }));
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : 'Failed to load todos';
+        update((state) => ({ ...state, loading: false, error: errorMessage }));
+        console.error('Failed to load todos:', error);
+      }
+    },
+
+    // Create a new todo
+    async createTodo(description: string) {
+      update((state) => ({ ...state, loading: true, error: null }));
+      
+      try {
+        const newTodo = await simpleTodosApi.createTodo({ description });
+        update((state) => ({
+          ...state,
+          todos: [newTodo, ...state.todos], // Add to the beginning
+          loading: false,
+        }));
+        return newTodo;
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : 'Failed to create todo';
+        update((state) => ({ ...state, loading: false, error: errorMessage }));
+        console.error('Failed to create todo:', error);
+        throw error;
+      }
+    },
+
+    // Update a todo
+    async updateTodo(id: string, description: string) {
+      update((state) => ({ ...state, loading: true, error: null }));
+      
+      try {
+        const updatedTodo = await simpleTodosApi.updateTodo(id, { description });
+        update((state) => ({
+          ...state,
+          todos: state.todos.map((todo) => (todo.id === id ? updatedTodo : todo)),
+          loading: false,
+        }));
+        return updatedTodo;
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : 'Failed to update todo';
+        update((state) => ({ ...state, loading: false, error: errorMessage }));
+        console.error('Failed to update todo:', error);
+        throw error;
+      }
+    },
+
+    // Complete/uncomplete a todo
+    async completeTodo(id: string, isCompleted: boolean) {
+      // Optimistically update the UI
+      update((state) => ({
+        ...state,
+        todos: state.todos.map((todo) =>
+          todo.id === id ? { ...todo, isCompleted, completedAt: isCompleted ? new Date().toISOString() : null } : todo
+        ),
+      }));
+
+      try {
+        const updatedTodo = await simpleTodosApi.completeTodo(id, isCompleted);
+        
+        if (isCompleted) {
+          // Remove completed todos from the list after a short delay for visual feedback
+          setTimeout(() => {
+            update((state) => ({
+              ...state,
+              todos: state.todos.filter((todo) => todo.id !== id),
+            }));
+          }, 1000);
+        } else {
+          // Update with server response
+          update((state) => ({
+            ...state,
+            todos: state.todos.map((todo) => (todo.id === id ? updatedTodo : todo)),
+          }));
+        }
+        
+        return updatedTodo;
+      } catch (error) {
+        // Revert optimistic update on error
+        update((state) => ({
+          ...state,
+          todos: state.todos.map((todo) =>
+            todo.id === id ? { ...todo, isCompleted: !isCompleted, completedAt: null } : todo
+          ),
+          error: error instanceof Error ? error.message : 'Failed to update todo',
+        }));
+        console.error('Failed to complete todo:', error);
+        throw error;
+      }
+    },
+
+    // Delete a todo
+    async deleteTodo(id: string) {
+      update((state) => ({ ...state, loading: true, error: null }));
+      
+      try {
+        await simpleTodosApi.deleteTodo(id);
+        update((state) => ({
+          ...state,
+          todos: state.todos.filter((todo) => todo.id !== id),
+          loading: false,
+        }));
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : 'Failed to delete todo';
+        update((state) => ({ ...state, loading: false, error: errorMessage }));
+        console.error('Failed to delete todo:', error);
+        throw error;
+      }
+    },
+
+    // Clear error
+    clearError() {
+      update((state) => ({ ...state, error: null }));
+    },
+
+    // Reset store
+    reset() {
+      set(initialState);
+    },
+  };
+};
+
+// Export the store instance
+export const simpleTodosStore = createSimpleTodosStore();
+
+// Derived stores for easier access to specific parts of the state
+export const todos = derived(simpleTodosStore, ($store) => $store.todos);
+export const todosLoading = derived(simpleTodosStore, ($store) => $store.loading);
+export const todosError = derived(simpleTodosStore, ($store) => $store.error);

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -2,6 +2,7 @@
   import { authStore, type User } from '$lib/stores/auth';
   import Navigation from '$lib/components/Navigation.svelte';
   import DailyFocusWidget from '$lib/components/focus/DailyFocusWidget.svelte';
+  import SimpleTodosWidget from '$lib/components/todos/SimpleTodosWidget.svelte';
 
   let user: User | null = null;
   let token: string | null = null;
@@ -54,6 +55,11 @@
               <!-- Daily Focus Widget -->
               <div class="mb-6">
                 <DailyFocusWidget />
+              </div>
+
+              <!-- Simple Todos Widget -->
+              <div class="mb-6">
+                <SimpleTodosWidget />
               </div>
 
               <div class="divider"></div>


### PR DESCRIPTION
Introduce functionality for users to create, view, and complete simple, one-off todo items, enhancing the homepage with a lightweight productivity aid. This feature includes backend CRUD operations, validation schemas, and frontend integration.