### PR TITLE
feat: Add avatar support for users and family members

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -75,7 +75,7 @@ jobs:
         with:
           payload: |
             {
-              "text": "GitHub Action Results for ${{ github.repository }}",
+              "text": "Journal App Build ${{ needs.build-and-push.result == 'success' && '✅ Success!' || '❌ Failure' }}",
               "blocks": [
                 {
                   "type": "header",

--- a/backend/src/db/migrations/0013_shiny_tomas.sql
+++ b/backend/src/db/migrations/0013_shiny_tomas.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "users" ADD COLUMN "avatar" text;--> statement-breakpoint
+ALTER TABLE "family_members" ADD COLUMN "avatar" text;

--- a/backend/src/db/migrations/meta/0013_snapshot.json
+++ b/backend/src/db/migrations/meta/0013_snapshot.json
@@ -1,0 +1,1328 @@
+{
+  "id": "73b772c9-240a-4a41-8b02-a6be72adda00",
+  "prevId": "1b1e5cf8-1109-4587-be7b-f7a4d293bd40",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.characters": {
+      "name": "characters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_class": {
+          "name": "character_class",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backstory": {
+          "name": "backstory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goals": {
+          "name": "goals",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "motto": {
+          "name": "motto",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "characters_user_id_users_id_fk": {
+          "name": "characters_user_id_users_id_fk",
+          "tableFrom": "characters",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.character_stat_level_titles": {
+      "name": "character_stat_level_titles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "stat_id": {
+          "name": "stat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "character_stat_level_titles_stat_id_character_stats_id_fk": {
+          "name": "character_stat_level_titles_stat_id_character_stats_id_fk",
+          "tableFrom": "character_stat_level_titles",
+          "tableTo": "character_stats",
+          "columnsFrom": [
+            "stat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.character_stat_xp_grants": {
+      "name": "character_stat_xp_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stat_id": {
+          "name": "stat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "xp_amount": {
+          "name": "xp_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "character_stat_xp_grants_user_id_users_id_fk": {
+          "name": "character_stat_xp_grants_user_id_users_id_fk",
+          "tableFrom": "character_stat_xp_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "character_stat_xp_grants_stat_id_character_stats_id_fk": {
+          "name": "character_stat_xp_grants_stat_id_character_stats_id_fk",
+          "tableFrom": "character_stat_xp_grants",
+          "tableTo": "character_stats",
+          "columnsFrom": [
+            "stat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.character_stats": {
+      "name": "character_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "example_activities": {
+          "name": "example_activities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "current_level": {
+          "name": "current_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "total_xp": {
+          "name": "total_xp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "character_stats_user_id_users_id_fk": {
+          "name": "character_stats_user_id_users_id_fk",
+          "tableFrom": "character_stats",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.goals": {
+      "name": "goals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "goals_user_id_users_id_fk": {
+          "name": "goals_user_id_users_id_fk",
+          "tableFrom": "goals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.family_members": {
+      "name": "family_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relationship": {
+          "name": "relationship",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birthday": {
+          "name": "birthday",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "likes": {
+          "name": "likes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dislikes": {
+          "name": "dislikes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "energy_level": {
+          "name": "energy_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 50
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_interaction_date": {
+          "name": "last_interaction_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection_xp": {
+          "name": "connection_xp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "connection_level": {
+          "name": "connection_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "family_members_user_id_users_id_fk": {
+          "name": "family_members_user_id_users_id_fk",
+          "tableFrom": "family_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.family_task_feedback": {
+      "name": "family_task_feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "family_member_id": {
+          "name": "family_member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_description": {
+          "name": "task_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enjoyed_it": {
+          "name": "enjoyed_it",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "xp_granted": {
+          "name": "xp_granted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "family_task_feedback_user_id_users_id_fk": {
+          "name": "family_task_feedback_user_id_users_id_fk",
+          "tableFrom": "family_task_feedback",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "family_task_feedback_family_member_id_family_members_id_fk": {
+          "name": "family_task_feedback_family_member_id_family_members_id_fk",
+          "tableFrom": "family_task_feedback",
+          "tableTo": "family_members",
+          "columnsFrom": [
+            "family_member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.goal_tags": {
+      "name": "goal_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "goal_id": {
+          "name": "goal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "goal_tags_goal_id_goals_id_fk": {
+          "name": "goal_tags_goal_id_goals_id_fk",
+          "tableFrom": "goal_tags",
+          "tableTo": "goals",
+          "columnsFrom": [
+            "goal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "goal_tags_tag_id_tags_id_fk": {
+          "name": "goal_tags_tag_id_tags_id_fk",
+          "tableFrom": "goal_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tags_user_id_users_id_fk": {
+          "name": "tags_user_id_users_id_fk",
+          "tableFrom": "tags",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_tag": {
+          "name": "unique_user_tag",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.focuses": {
+      "name": "focuses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "focuses_user_id_users_id_fk": {
+          "name": "focuses_user_id_users_id_fk",
+          "tableFrom": "focuses",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.journal_conversation_messages": {
+      "name": "journal_conversation_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_order": {
+          "name": "message_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "journal_conversation_messages_entry_id_journal_entries_id_fk": {
+          "name": "journal_conversation_messages_entry_id_journal_entries_id_fk",
+          "tableFrom": "journal_conversation_messages",
+          "tableTo": "journal_entries",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.journal_entries": {
+      "name": "journal_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synopsis": {
+          "name": "synopsis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "journal_entries_user_id_users_id_fk": {
+          "name": "journal_entries_user_id_users_id_fk",
+          "tableFrom": "journal_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.journal_entry_stat_tags": {
+      "name": "journal_entry_stat_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stat_id": {
+          "name": "stat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "journal_entry_stat_tags_entry_id_journal_entries_id_fk": {
+          "name": "journal_entry_stat_tags_entry_id_journal_entries_id_fk",
+          "tableFrom": "journal_entry_stat_tags",
+          "tableTo": "journal_entries",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "journal_entry_stat_tags_stat_id_character_stats_id_fk": {
+          "name": "journal_entry_stat_tags_stat_id_character_stats_id_fk",
+          "tableFrom": "journal_entry_stat_tags",
+          "tableTo": "character_stats",
+          "columnsFrom": [
+            "stat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.journal_entry_tags": {
+      "name": "journal_entry_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "journal_entry_tags_entry_id_journal_entries_id_fk": {
+          "name": "journal_entry_tags_entry_id_journal_entries_id_fk",
+          "tableFrom": "journal_entry_tags",
+          "tableTo": "journal_entries",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "journal_entry_tags_tag_id_tags_id_fk": {
+          "name": "journal_entry_tags_tag_id_tags_id_fk",
+          "tableFrom": "journal_entry_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.journal_sessions": {
+      "name": "journal_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messages": {
+          "name": "messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'true'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "journal_sessions_user_id_users_id_fk": {
+          "name": "journal_sessions_user_id_users_id_fk",
+          "tableFrom": "journal_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simple_todos": {
+      "name": "simple_todos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_completed": {
+          "name": "is_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "simple_todos_user_id_users_id_fk": {
+          "name": "simple_todos_user_id_users_id_fk",
+          "tableFrom": "simple_todos",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/src/db/migrations/meta/_journal.json
+++ b/backend/src/db/migrations/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1752205696619,
       "tag": "0012_flaky_molten_man",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1752260020641,
+      "tag": "0013_shiny_tomas",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/db/schema/family.ts
+++ b/backend/src/db/schema/family.ts
@@ -13,6 +13,7 @@ export const familyMembers = pgTable('family_members', {
   dislikes: text('dislikes'), // Freeform text for dislikes
   energyLevel: integer('energy_level').default(50), // Energy level 1-100, default 50
   notes: text('notes'), // Additional notes about the family member
+  avatar: text('avatar'), // Base64 encoded image data
   lastInteractionDate: timestamp('last_interaction_date'), // Auto-updated when tasks are completed
   connectionXp: integer('connection_xp').default(0).notNull(), // XP for relationship progress
   connectionLevel: integer('connection_level').default(1).notNull(), // Calculated level based on XP

--- a/backend/src/db/schema/users.ts
+++ b/backend/src/db/schema/users.ts
@@ -1,10 +1,11 @@
-import { pgTable, uuid, varchar, timestamp } from 'drizzle-orm/pg-core';
+import { pgTable, uuid, varchar, timestamp, text } from 'drizzle-orm/pg-core';
 
 export const users = pgTable('users', {
   id: uuid('id').primaryKey().defaultRandom(),
   name: varchar('name', { length: 100 }).notNull(),
   email: varchar('email', { length: 255 }).notNull().unique(),
   password: varchar('password', { length: 255 }).notNull(),
+  avatar: text('avatar'), // Base64 encoded image data
   createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
   updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
 });

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -6,7 +6,12 @@ import { env } from '../env';
 import { eq } from 'drizzle-orm';
 import { sign } from 'hono/jwt';
 import { hashPassword, verifyPassword } from '../utils/auth';
-import { registerSchema, loginSchema } from '../validation/users';
+import { registerSchema, loginSchema, updateUserValidationSchema } from '../validation/users';
+import { jwtAuth } from '../middleware/auth';
+import type { UpdateUserRequest, UpdateUserAvatarRequest } from '../types/users';
+import logger, { handleApiError } from '../utils/logger';
+import { z } from 'zod';
+import { createAvatarSchema } from '../utils/avatar';
 
 // Chain methods for RPC compatibility
 const app = new Hono()
@@ -41,18 +46,20 @@ const app = new Hono()
           name,
           email,
           password: hashedPassword,
+          avatar: data.avatar || null,
         })
         .returning({
           id: users.id,
           name: users.name,
           email: users.email,
+          avatar: users.avatar,
           createdAt: users.createdAt,
         });
 
       // Generate JWT token
       const token = await sign(
         {
-          id: newUser.id,
+          userId: newUser.id,
           email: newUser.email,
           name: newUser.name,
           iat: Math.floor(Date.now() / 1000), // issued at
@@ -97,7 +104,7 @@ const app = new Hono()
       const expirationTime = rememberMe ? 30 * 24 * 60 * 60 : 24 * 60 * 60; // 30 days or 24 hours
       const token = await sign(
         {
-          id: user.id,
+          userId: user.id,
           email: user.email,
           name: user.name,
           iat: Math.floor(Date.now() / 1000), // issued at
@@ -112,6 +119,7 @@ const app = new Hono()
             id: user.id,
             name: user.name,
             email: user.email,
+            avatar: user.avatar,
             createdAt: user.createdAt,
           },
           token,
@@ -121,6 +129,141 @@ const app = new Hono()
     } catch (error) {
       console.error('Login error:', error);
       return c.json({ error: 'Failed to login user' }, 500);
+    }
+  })
+  // Get current user profile
+  .get('/profile', jwtAuth, async (c) => {
+    try {
+      const userId = c.get('userId');
+
+      const userProfile = await db
+        .select({
+          id: users.id,
+          name: users.name,
+          email: users.email,
+          avatar: users.avatar,
+          createdAt: users.createdAt,
+          updatedAt: users.updatedAt,
+        })
+        .from(users)
+        .where(eq(users.id, userId))
+        .limit(1);
+
+      if (userProfile.length === 0) {
+        return c.json(
+          {
+            success: false,
+            error: 'User not found',
+          },
+          404,
+        );
+      }
+
+      return c.json({
+        success: true,
+        data: userProfile[0],
+      });
+    } catch (error) {
+      return handleApiError(error, 'Failed to fetch user profile');
+    }
+  })
+  // Update user profile
+  .put('/profile', jwtAuth, zValidator('json', updateUserValidationSchema), async (c) => {
+    try {
+      const userId = c.get('userId');
+      const data = c.req.valid('json') as UpdateUserRequest;
+
+      // Check if email is being changed and if it's already in use
+      if (data.email) {
+        const existingUsers = await db.select().from(users).where(eq(users.email, data.email)).limit(1);
+
+        if (existingUsers.length > 0 && existingUsers[0].id !== userId) {
+          return c.json(
+            {
+              success: false,
+              error: 'Email already in use',
+            },
+            409,
+          );
+        }
+      }
+
+      const updatedUser = await db
+        .update(users)
+        .set({
+          ...data,
+          updatedAt: new Date(),
+        })
+        .where(eq(users.id, userId))
+        .returning({
+          id: users.id,
+          name: users.name,
+          email: users.email,
+          avatar: users.avatar,
+          createdAt: users.createdAt,
+          updatedAt: users.updatedAt,
+        });
+
+      if (updatedUser.length === 0) {
+        return c.json(
+          {
+            success: false,
+            error: 'User not found',
+          },
+          404,
+        );
+      }
+
+      logger.info(`User profile updated: ${updatedUser[0].email}`);
+
+      return c.json({
+        success: true,
+        data: updatedUser[0],
+      });
+    } catch (error) {
+      return handleApiError(error, 'Failed to update user profile');
+    }
+  })
+  // Update/remove user avatar
+  .patch('/avatar', jwtAuth, zValidator('json', z.object(createAvatarSchema())), async (c) => {
+    try {
+      const userId = c.get('userId');
+      const data = c.req.valid('json') as UpdateUserAvatarRequest;
+
+      const updatedUser = await db
+        .update(users)
+        .set({
+          avatar: data.avatar || null,
+          updatedAt: new Date(),
+        })
+        .where(eq(users.id, userId))
+        .returning({
+          id: users.id,
+          name: users.name,
+          email: users.email,
+          avatar: users.avatar,
+          createdAt: users.createdAt,
+          updatedAt: users.updatedAt,
+        });
+
+      if (updatedUser.length === 0) {
+        return c.json(
+          {
+            success: false,
+            error: 'User not found',
+          },
+          404,
+        );
+      }
+
+      logger.info(`User avatar ${data.avatar ? 'updated' : 'removed'}: ${updatedUser[0].email}`);
+
+      return c.json({
+        success: true,
+        data: updatedUser[0],
+      });
+    } catch (error) {
+      return handleApiError(error, 'Failed to update user avatar');
     }
   });
 

--- a/backend/src/tests/auth-flow.test.ts
+++ b/backend/src/tests/auth-flow.test.ts
@@ -140,7 +140,7 @@ describe('Authentication Flow Integration Tests', () => {
       const decodedPayload = JSON.parse(Buffer.from(payload.replace(/-/g, '+').replace(/_/g, '/'), 'base64').toString());
 
       // Verify payload contains user information
-      expect(decodedPayload).toHaveProperty('id', responseData.user.id);
+      expect(decodedPayload).toHaveProperty('userId', responseData.user.id);
       expect(decodedPayload).toHaveProperty('name', userData.name);
 
       // Should not contain sensitive information

--- a/backend/src/types/family.ts
+++ b/backend/src/types/family.ts
@@ -19,6 +19,7 @@ export interface CreateFamilyMemberRequest {
   dislikes?: string;
   energyLevel: number;
   notes?: string;
+  avatar?: string; // Base64 encoded image
 }
 
 export interface UpdateFamilyMemberRequest extends Partial<CreateFamilyMemberRequest> {}

--- a/backend/src/types/users.ts
+++ b/backend/src/types/users.ts
@@ -6,3 +6,14 @@ export type UserUpdate = Partial<Omit<NewUser, 'id' | 'createdAt'>>;
 
 // Exclude sensitive fields for API responses
 export type PublicUser = Omit<User, 'password'>;
+
+// API request types
+export interface UpdateUserRequest {
+  name?: string;
+  email?: string;
+  avatar?: string; // Base64 encoded image
+}
+
+export interface UpdateUserAvatarRequest {
+  avatar?: string; // Base64 encoded image (empty string to remove)
+}

--- a/backend/src/utils/avatar.ts
+++ b/backend/src/utils/avatar.ts
@@ -1,0 +1,86 @@
+/**
+ * Avatar utility functions for base64 image validation and processing
+ */
+import { z } from 'zod';
+
+// Maximum file size in bytes (2MB)
+const MAX_AVATAR_SIZE = 2 * 1024 * 1024;
+
+// Allowed image formats
+const ALLOWED_FORMATS = ['image/jpeg', 'image/png', 'image/webp'];
+
+/**
+ * Validates a base64 encoded image string
+ * @param base64String - The base64 string to validate
+ * @returns true if valid, throws error if invalid
+ */
+export function validateBase64Image(base64String: string): boolean {
+  // Check if it's a valid base64 data URL
+  const dataUrlRegex = /^data:([a-zA-Z0-9][a-zA-Z0-9\/+]*);base64,(.+)$/;
+  const match = base64String.match(dataUrlRegex);
+
+  if (!match) {
+    throw new Error('Invalid base64 image format. Must be a data URL.');
+  }
+
+  const [, mimeType, base64Data] = match;
+
+  // Validate MIME type
+  if (!ALLOWED_FORMATS.includes(mimeType)) {
+    throw new Error(`Unsupported image format. Allowed formats: ${ALLOWED_FORMATS.join(', ')}`);
+  }
+
+  // Validate base64 data format
+  const base64Regex = /^[A-Za-z0-9+/]*={0,2}$/;
+  if (!base64Regex.test(base64Data)) {
+    throw new Error('Invalid base64 data format');
+  }
+
+  // Validate base64 data
+  try {
+    const buffer = Buffer.from(base64Data, 'base64');
+
+    // Check if the decoded length makes sense
+    const expectedLength = Math.floor((base64Data.length * 3) / 4);
+    if (Math.abs(buffer.length - expectedLength) > 2) {
+      throw new Error('Invalid base64 data - length mismatch');
+    }
+
+    // Check file size
+    if (buffer.length > MAX_AVATAR_SIZE) {
+      throw new Error(`Image too large. Maximum size: ${MAX_AVATAR_SIZE / (1024 * 1024)}MB`);
+    }
+
+    return true;
+  } catch (error) {
+    if (error instanceof Error) {
+      throw error;
+    }
+    throw new Error('Invalid base64 data');
+  }
+}
+
+/**
+ * Creates a Zod schema for validating base64 avatar images
+ */
+export function createAvatarSchema() {
+  return {
+    avatar: z
+      .string()
+      .optional()
+      .refine(
+        (value: string | undefined) => {
+          if (!value) return true; // Optional field
+          try {
+            validateBase64Image(value);
+            return true;
+          } catch {
+            return false;
+          }
+        },
+        {
+          message: 'Invalid avatar image. Must be a base64 encoded image (JPEG, PNG, or WebP) under 2MB',
+        },
+      ),
+  };
+}

--- a/backend/src/validation/family.ts
+++ b/backend/src/validation/family.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { createAvatarSchema } from '../utils/avatar';
 
 // Family member validation schemas
 export const createFamilyMemberSchema = z.object({
@@ -12,6 +13,7 @@ export const createFamilyMemberSchema = z.object({
   dislikes: z.string().max(1000, 'Dislikes must be 1000 characters or less').optional(),
   energyLevel: z.number().int().min(1).max(100).default(50),
   notes: z.string().max(1000, 'Notes must be 1000 characters or less').optional(),
+  ...createAvatarSchema(),
 });
 
 export const updateFamilyMemberSchema = createFamilyMemberSchema.partial();

--- a/backend/src/validation/users.ts
+++ b/backend/src/validation/users.ts
@@ -1,10 +1,12 @@
 import { z } from 'zod';
+import { createAvatarSchema } from '../utils/avatar';
 
 // Base user validation schema
 export const userValidationSchema = z.object({
   name: z.string().min(1).max(100),
   email: z.string().email(),
   password: z.string().min(6),
+  ...createAvatarSchema(),
 });
 
 // Registration schema with detailed error messages
@@ -14,6 +16,8 @@ export const registerSchema = z.object({
   email: z.string().min(1, 'Email is required').email('Invalid email format'),
 
   password: z.string().min(6, 'Password must be at least 6 characters'),
+
+  ...createAvatarSchema(),
 });
 
 // Login schema

--- a/frontend/src/lib/components/Navigation.svelte
+++ b/frontend/src/lib/components/Navigation.svelte
@@ -67,7 +67,7 @@
             <span class="text-xs">Signed in as <strong>{user.email}</strong></span>
           </li>
           <div class="divider my-2"></div>
-          
+
           <!-- Mobile-only: Show additional nav links in user menu -->
           <div class="lg:hidden">
             <li class="menu-title">
@@ -75,37 +75,98 @@
             </li>
             <li>
               <a href="/character" class="text-base-content" on:click={closeDropdown}>
-                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-4 w-4"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="20"
+                  height="20"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  class="h-4 w-4"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" /><circle cx="12" cy="7" r="4" /></svg
+                >
                 Character
               </a>
             </li>
             <li>
               <a href="/journal" class="text-base-content" on:click={closeDropdown}>
-                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-4 w-4"><path d="M4 19.5v-15A2.5 2.5 0 0 1 6.5 2H20v20H6.5a2.5 2.5 0 0 1 0-5H20"/></svg>
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="20"
+                  height="20"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  class="h-4 w-4"><path d="M4 19.5v-15A2.5 2.5 0 0 1 6.5 2H20v20H6.5a2.5 2.5 0 0 1 0-5H20" /></svg
+                >
                 Journal
               </a>
             </li>
             <li>
               <a href="/goals" class="text-base-content" on:click={closeDropdown}>
-                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-4 w-4"><circle cx="12" cy="12" r="10"/><path d="m9 12 2 2 4-4"/></svg>
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="20"
+                  height="20"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  class="h-4 w-4"><circle cx="12" cy="12" r="10" /><path d="m9 12 2 2 4-4" /></svg
+                >
                 Goals
               </a>
             </li>
             <li>
               <a href="/stats" class="text-base-content" on:click={closeDropdown}>
-                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-4 w-4"><line x1="18" y1="20" x2="18" y2="10"/><line x1="12" y1="20" x2="12" y2="4"/><line x1="6" y1="20" x2="6" y2="14"/></svg>
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="20"
+                  height="20"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  class="h-4 w-4"><line x1="18" y1="20" x2="18" y2="10" /><line x1="12" y1="20" x2="12" y2="4" /><line x1="6" y1="20" x2="6" y2="14" /></svg
+                >
                 Stats
               </a>
             </li>
             <li>
               <a href="/family" class="text-base-content" on:click={closeDropdown}>
-                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-4 w-4"><path d="m9 12 2 2 4-4"/><path d="M21 5c0 1.1-.9 2-2 2H5c-1.1 0-2-.9-2-2s.9-2 2-2h14c1.1 0 2 .9 2 2Z"/><path d="M17 17H7l4 4 4-4Z"/></svg>
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="20"
+                  height="20"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  class="h-4 w-4"
+                  ><path d="m9 12 2 2 4-4" /><path d="M21 5c0 1.1-.9 2-2 2H5c-1.1 0-2-.9-2-2s.9-2 2-2h14c1.1 0 2 .9 2 2Z" /><path d="M17 17H7l4 4 4-4Z" /></svg
+                >
                 Family
               </a>
             </li>
             <li>
               <a href="/focus" class="text-base-content" on:click={closeDropdown}>
-                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-4 w-4"><circle cx="12" cy="12" r="3"/><path d="M12 1v6m0 6v6m11-7h-6m-6 0H1"/></svg>
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="20"
+                  height="20"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  class="h-4 w-4"><circle cx="12" cy="12" r="3" /><path d="M12 1v6m0 6v6m11-7h-6m-6 0H1" /></svg
+                >
                 Focus
               </a>
             </li>
@@ -119,13 +180,34 @@
             </li>
             <li>
               <a href="/family" class="text-base-content" on:click={closeDropdown}>
-                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-4 w-4"><path d="m9 12 2 2 4-4"/><path d="M21 5c0 1.1-.9 2-2 2H5c-1.1 0-2-.9-2-2s.9-2 2-2h14c1.1 0 2 .9 2 2Z"/><path d="M17 17H7l4 4 4-4Z"/></svg>
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="20"
+                  height="20"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  class="h-4 w-4"
+                  ><path d="m9 12 2 2 4-4" /><path d="M21 5c0 1.1-.9 2-2 2H5c-1.1 0-2-.9-2-2s.9-2 2-2h14c1.1 0 2 .9 2 2Z" /><path d="M17 17H7l4 4 4-4Z" /></svg
+                >
                 Family
               </a>
             </li>
             <li>
               <a href="/focus" class="text-base-content" on:click={closeDropdown}>
-                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-4 w-4"><circle cx="12" cy="12" r="3"/><path d="M12 1v6m0 6v6m11-7h-6m-6 0H1"/></svg>
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="20"
+                  height="20"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  class="h-4 w-4"><circle cx="12" cy="12" r="3" /><path d="M12 1v6m0 6v6m11-7h-6m-6 0H1" /></svg
+                >
                 Focus
               </a>
             </li>


### PR DESCRIPTION
- Add avatar field to users and family_members database schemas
- Create avatar validation utility with base64 image support
- Support JPEG, PNG, WebP formats up to 2MB in size
- Add avatar endpoints for user profile and family member management
- Comprehensive test coverage for avatar functionality
- All 236 backend tests passing