### PR TITLE
Generic XP grant implementation and frontend updates

### DIFF
--- a/backend/src/db/migrations/0014_clever_jack_murdock.sql
+++ b/backend/src/db/migrations/0014_clever_jack_murdock.sql
@@ -1,0 +1,14 @@
+CREATE TABLE "xp_grants" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"entity_type" varchar(50) NOT NULL,
+	"entity_id" uuid NOT NULL,
+	"xp_amount" integer NOT NULL,
+	"source_type" varchar(50) NOT NULL,
+	"source_id" uuid,
+	"reason" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DROP TABLE "character_stat_xp_grants" CASCADE;--> statement-breakpoint
+ALTER TABLE "xp_grants" ADD CONSTRAINT "xp_grants_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;

--- a/backend/src/db/migrations/meta/0014_snapshot.json
+++ b/backend/src/db/migrations/meta/0014_snapshot.json
@@ -1,0 +1,1321 @@
+{
+  "id": "2e1b9241-8d24-497f-87a2-4ef594f91ef4",
+  "prevId": "73b772c9-240a-4a41-8b02-a6be72adda00",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.characters": {
+      "name": "characters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_class": {
+          "name": "character_class",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backstory": {
+          "name": "backstory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goals": {
+          "name": "goals",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "motto": {
+          "name": "motto",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "characters_user_id_users_id_fk": {
+          "name": "characters_user_id_users_id_fk",
+          "tableFrom": "characters",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.character_stat_level_titles": {
+      "name": "character_stat_level_titles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "stat_id": {
+          "name": "stat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "character_stat_level_titles_stat_id_character_stats_id_fk": {
+          "name": "character_stat_level_titles_stat_id_character_stats_id_fk",
+          "tableFrom": "character_stat_level_titles",
+          "tableTo": "character_stats",
+          "columnsFrom": [
+            "stat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.character_stats": {
+      "name": "character_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "example_activities": {
+          "name": "example_activities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "current_level": {
+          "name": "current_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "total_xp": {
+          "name": "total_xp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "character_stats_user_id_users_id_fk": {
+          "name": "character_stats_user_id_users_id_fk",
+          "tableFrom": "character_stats",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.xp_grants": {
+      "name": "xp_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "xp_amount": {
+          "name": "xp_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "xp_grants_user_id_users_id_fk": {
+          "name": "xp_grants_user_id_users_id_fk",
+          "tableFrom": "xp_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.goals": {
+      "name": "goals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "goals_user_id_users_id_fk": {
+          "name": "goals_user_id_users_id_fk",
+          "tableFrom": "goals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.family_members": {
+      "name": "family_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relationship": {
+          "name": "relationship",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birthday": {
+          "name": "birthday",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "likes": {
+          "name": "likes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dislikes": {
+          "name": "dislikes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "energy_level": {
+          "name": "energy_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 50
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_interaction_date": {
+          "name": "last_interaction_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection_xp": {
+          "name": "connection_xp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "connection_level": {
+          "name": "connection_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "family_members_user_id_users_id_fk": {
+          "name": "family_members_user_id_users_id_fk",
+          "tableFrom": "family_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.family_task_feedback": {
+      "name": "family_task_feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "family_member_id": {
+          "name": "family_member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_description": {
+          "name": "task_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enjoyed_it": {
+          "name": "enjoyed_it",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "xp_granted": {
+          "name": "xp_granted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "family_task_feedback_user_id_users_id_fk": {
+          "name": "family_task_feedback_user_id_users_id_fk",
+          "tableFrom": "family_task_feedback",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "family_task_feedback_family_member_id_family_members_id_fk": {
+          "name": "family_task_feedback_family_member_id_family_members_id_fk",
+          "tableFrom": "family_task_feedback",
+          "tableTo": "family_members",
+          "columnsFrom": [
+            "family_member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.goal_tags": {
+      "name": "goal_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "goal_id": {
+          "name": "goal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "goal_tags_goal_id_goals_id_fk": {
+          "name": "goal_tags_goal_id_goals_id_fk",
+          "tableFrom": "goal_tags",
+          "tableTo": "goals",
+          "columnsFrom": [
+            "goal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "goal_tags_tag_id_tags_id_fk": {
+          "name": "goal_tags_tag_id_tags_id_fk",
+          "tableFrom": "goal_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tags_user_id_users_id_fk": {
+          "name": "tags_user_id_users_id_fk",
+          "tableFrom": "tags",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_tag": {
+          "name": "unique_user_tag",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.focuses": {
+      "name": "focuses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "focuses_user_id_users_id_fk": {
+          "name": "focuses_user_id_users_id_fk",
+          "tableFrom": "focuses",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.journal_conversation_messages": {
+      "name": "journal_conversation_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_order": {
+          "name": "message_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "journal_conversation_messages_entry_id_journal_entries_id_fk": {
+          "name": "journal_conversation_messages_entry_id_journal_entries_id_fk",
+          "tableFrom": "journal_conversation_messages",
+          "tableTo": "journal_entries",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.journal_entries": {
+      "name": "journal_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synopsis": {
+          "name": "synopsis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "journal_entries_user_id_users_id_fk": {
+          "name": "journal_entries_user_id_users_id_fk",
+          "tableFrom": "journal_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.journal_entry_stat_tags": {
+      "name": "journal_entry_stat_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stat_id": {
+          "name": "stat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "journal_entry_stat_tags_entry_id_journal_entries_id_fk": {
+          "name": "journal_entry_stat_tags_entry_id_journal_entries_id_fk",
+          "tableFrom": "journal_entry_stat_tags",
+          "tableTo": "journal_entries",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "journal_entry_stat_tags_stat_id_character_stats_id_fk": {
+          "name": "journal_entry_stat_tags_stat_id_character_stats_id_fk",
+          "tableFrom": "journal_entry_stat_tags",
+          "tableTo": "character_stats",
+          "columnsFrom": [
+            "stat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.journal_entry_tags": {
+      "name": "journal_entry_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "journal_entry_tags_entry_id_journal_entries_id_fk": {
+          "name": "journal_entry_tags_entry_id_journal_entries_id_fk",
+          "tableFrom": "journal_entry_tags",
+          "tableTo": "journal_entries",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "journal_entry_tags_tag_id_tags_id_fk": {
+          "name": "journal_entry_tags_tag_id_tags_id_fk",
+          "tableFrom": "journal_entry_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.journal_sessions": {
+      "name": "journal_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messages": {
+          "name": "messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'true'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "journal_sessions_user_id_users_id_fk": {
+          "name": "journal_sessions_user_id_users_id_fk",
+          "tableFrom": "journal_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simple_todos": {
+      "name": "simple_todos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_completed": {
+          "name": "is_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "simple_todos_user_id_users_id_fk": {
+          "name": "simple_todos_user_id_users_id_fk",
+          "tableFrom": "simple_todos",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/src/db/migrations/meta/_journal.json
+++ b/backend/src/db/migrations/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1752260020641,
       "tag": "0013_shiny_tomas",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1752286815836,
+      "tag": "0014_clever_jack_murdock",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/db/schema/stats.ts
+++ b/backend/src/db/schema/stats.ts
@@ -17,17 +17,17 @@ export const characterStats = pgTable('character_stats', {
   updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
 });
 
-// XP grants table - tracks all XP grants for auditing and history
-export const characterStatXpGrants = pgTable('character_stat_xp_grants', {
+// Generic XP grants table - tracks all XP grants for auditing and history across multiple entity types
+export const xpGrants = pgTable('xp_grants', {
   id: uuid('id').primaryKey().defaultRandom(),
   userId: uuid('user_id')
     .notNull()
     .references(() => users.id, { onDelete: 'cascade' }),
-  statId: uuid('stat_id')
-    .notNull()
-    .references(() => characterStats.id, { onDelete: 'cascade' }),
+  // Generic entity reference - can be character_stat, family_member, goal, project, etc.
+  entityType: varchar('entity_type', { length: 50 }).notNull(), // 'character_stat', 'family_member', 'goal', 'project', 'adventure'
+  entityId: uuid('entity_id').notNull(), // References the specific entity (stat ID, family member ID, etc.)
   xpAmount: integer('xp_amount').notNull(),
-  sourceType: varchar('source_type', { length: 50 }).notNull(), // 'task', 'journal', 'adhoc', 'quest'
+  sourceType: varchar('source_type', { length: 50 }).notNull(), // 'task', 'journal', 'adhoc', 'quest', 'interaction'
   sourceId: uuid('source_id'), // Optional reference to the source (task ID, journal entry ID, etc.)
   reason: text('reason'), // Optional GPT-generated reason or user comment
   createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),

--- a/backend/src/routes/journal.ts
+++ b/backend/src/routes/journal.ts
@@ -12,10 +12,11 @@ import {
   tags,
   characterStats,
   characters,
-  characterStatXpGrants,
+  xpGrants,
 } from '../db/schema';
 import { startJournalSessionSchema, sendJournalMessageSchema, saveJournalEntrySchema, getJournalEntrySchema } from '../validation/journal';
 import { handleApiError } from '../utils/logger';
+import { grantXp } from '../utils/xpService';
 import type {
   StartJournalSessionResponse,
   SendJournalMessageResponse,
@@ -283,10 +284,10 @@ const app = new Hono()
             statId: stat.id,
           });
 
-          // Grant XP to the stat
-          await db.insert(characterStatXpGrants).values({
-            userId,
-            statId: stat.id,
+          // Grant XP to the stat using the service
+          await grantXp(userId, {
+            entityType: 'character_stat',
+            entityId: stat.id,
             xpAmount,
             sourceType: 'journal',
             sourceId: entryId,

--- a/backend/src/tests/setup.ts
+++ b/backend/src/tests/setup.ts
@@ -55,7 +55,7 @@ export async function cleanDatabase() {
     // Tags (referenced by goal_tags)
     await safeDelete(schema.tags, 'tags');
     // Stats tables (they reference characters and users)
-    await safeDelete(schema.characterStatXpGrants, 'character_stat_xp_grants');
+    await safeDelete(schema.xpGrants, 'xp_grants');
     await safeDelete(schema.characterStatLevelTitles, 'character_stat_level_titles');
     await safeDelete(schema.characterStats, 'character_stats');
     await safeDelete(schema.goals, 'goals');

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -6,6 +6,7 @@ export * from './family';
 export * from './tags';
 export * from './focus';
 export * from './todos';
+export * from './xp';
 // Future exports:
 // export * from './posts';
 // export * from './auth';

--- a/backend/src/types/stats.ts
+++ b/backend/src/types/stats.ts
@@ -1,5 +1,5 @@
 import { InferInsertModel, InferSelectModel } from 'drizzle-orm';
-import { characterStats, characterStatXpGrants, characterStatLevelTitles } from '../db/schema/stats';
+import { characterStats, characterStatLevelTitles } from '../db/schema/stats';
 
 // Character Stats types
 export type CharacterStat = InferSelectModel<typeof characterStats>;
@@ -10,11 +10,7 @@ export type CharacterStatExampleActivity = {
   suggestedXp: number;
 };
 
-// XP Grant types
-export type CharacterStatXpGrant = InferSelectModel<typeof characterStatXpGrants>;
-export type NewCharacterStatXpGrant = InferInsertModel<typeof characterStatXpGrants>;
-
-export type XpSourceType = 'task' | 'journal' | 'adhoc' | 'quest' | 'experiment';
+// XP Grant types (generic for all entity types) - moved to xp.ts
 
 // Level Title types
 export type CharacterStatLevelTitle = InferSelectModel<typeof characterStatLevelTitles>;

--- a/backend/src/types/xp.ts
+++ b/backend/src/types/xp.ts
@@ -1,0 +1,37 @@
+import { InferInsertModel, InferSelectModel } from 'drizzle-orm';
+import { xpGrants } from '../db/schema/stats';
+
+// XP Grant types (generic for all entity types)
+export type XpGrant = InferSelectModel<typeof xpGrants>;
+export type NewXpGrant = InferInsertModel<typeof xpGrants>;
+
+// Supported entity types for XP grants
+export type XpEntityType = 'character_stat' | 'family_member' | 'goal' | 'project' | 'adventure';
+
+// Supported source types for XP grants
+export type XpSourceType = 'task' | 'journal' | 'adhoc' | 'quest' | 'experiment' | 'interaction';
+
+// Helper interface for creating XP grants with additional context
+export interface CreateXpGrantRequest {
+  entityType: XpEntityType;
+  entityId: string;
+  xpAmount: number;
+  sourceType: XpSourceType;
+  sourceId?: string;
+  reason?: string;
+}
+
+// Interface for filtering XP grants by entity
+export interface XpGrantFilter {
+  entityType?: XpEntityType;
+  entityId?: string;
+  sourceType?: XpSourceType;
+  limit?: number;
+  offset?: number;
+}
+
+// Interface for XP grant with related entity information
+export interface XpGrantWithEntity extends XpGrant {
+  entityName?: string; // Name of the entity (stat name, family member name, etc.)
+  entityDescription?: string; // Description for context
+}

--- a/backend/src/utils/xpService.ts
+++ b/backend/src/utils/xpService.ts
@@ -1,0 +1,210 @@
+import { eq, and, desc, sql } from 'drizzle-orm';
+import { db } from '../db';
+import { xpGrants, characterStats, familyMembers } from '../db/schema';
+import type { XpGrant, NewXpGrant, CreateXpGrantRequest, XpGrantFilter, XpGrantWithEntity, XpEntityType, XpSourceType } from '../types/xp';
+
+/**
+ * Grant XP to any entity (character stat, family member, goal, etc.)
+ */
+export async function grantXp(userId: string, request: CreateXpGrantRequest): Promise<XpGrant> {
+  try {
+    // First create the XP grant record
+    const [xpGrant] = await db
+      .insert(xpGrants)
+      .values({
+        userId,
+        ...request,
+      })
+      .returning();
+
+    // Then update the actual entity's XP if applicable
+    await updateEntityXp(request.entityType, request.entityId, request.xpAmount);
+
+    return xpGrant;
+  } catch (error) {
+    console.error('Error granting XP:', error);
+    throw error;
+  }
+}
+
+/**
+ * Update the XP for the specific entity type
+ */
+async function updateEntityXp(entityType: XpEntityType, entityId: string, xpAmount: number): Promise<void> {
+  try {
+    switch (entityType) {
+      case 'character_stat':
+        // Update character stat's total XP
+        const [currentStat] = await db.select({ totalXp: characterStats.totalXp }).from(characterStats).where(eq(characterStats.id, entityId));
+
+        if (currentStat) {
+          await db
+            .update(characterStats)
+            .set({
+              totalXp: currentStat.totalXp + xpAmount,
+              updatedAt: new Date(),
+            })
+            .where(eq(characterStats.id, entityId));
+        }
+        break;
+
+      case 'family_member':
+        // Update family member's connection XP
+        const [currentMember] = await db.select({ connectionXp: familyMembers.connectionXp }).from(familyMembers).where(eq(familyMembers.id, entityId));
+
+        if (currentMember) {
+          const newXp = currentMember.connectionXp + xpAmount;
+          const newLevel = Math.floor(newXp / 100) + 1;
+
+          await db
+            .update(familyMembers)
+            .set({
+              connectionXp: newXp,
+              connectionLevel: newLevel,
+              updatedAt: new Date(),
+            })
+            .where(eq(familyMembers.id, entityId));
+        }
+        break;
+
+      case 'goal':
+      case 'project':
+      case 'adventure':
+        // For future entity types, we can add XP tracking fields to their tables
+        // For now, these are tracked in the xp_grants table only
+        break;
+    }
+  } catch (error) {
+    console.error(`Error updating entity XP for ${entityType}:`, error);
+    throw error; // Re-throw to be handled by the caller
+  }
+}
+
+/**
+ * Get XP grants with optional filtering
+ */
+export async function getXpGrants(userId: string, filter: XpGrantFilter = {}): Promise<XpGrant[]> {
+  // Build where conditions
+  const conditions = [eq(xpGrants.userId, userId)];
+
+  if (filter.entityType) {
+    conditions.push(eq(xpGrants.entityType, filter.entityType));
+  }
+
+  if (filter.entityId) {
+    conditions.push(eq(xpGrants.entityId, filter.entityId));
+  }
+
+  if (filter.sourceType) {
+    conditions.push(eq(xpGrants.sourceType, filter.sourceType));
+  }
+
+  // Build the query with all conditions at once
+  const baseQuery = db
+    .select()
+    .from(xpGrants)
+    .where(and(...conditions))
+    .orderBy(desc(xpGrants.createdAt));
+
+  // Handle pagination
+  if (filter.limit !== undefined && filter.offset !== undefined) {
+    return await baseQuery.limit(filter.limit).offset(filter.offset);
+  } else if (filter.limit !== undefined) {
+    return await baseQuery.limit(filter.limit);
+  } else {
+    return await baseQuery;
+  }
+}
+
+/**
+ * Get XP grants with entity information
+ */
+export async function getXpGrantsWithEntityInfo(userId: string, filter: XpGrantFilter = {}): Promise<XpGrantWithEntity[]> {
+  const grants = await getXpGrants(userId, filter);
+
+  // Enhance grants with entity information
+  const grantsWithEntity: XpGrantWithEntity[] = [];
+
+  for (const grant of grants) {
+    let entityName: string | undefined;
+    let entityDescription: string | undefined;
+
+    switch (grant.entityType) {
+      case 'character_stat':
+        const [stat] = await db
+          .select({ name: characterStats.name, description: characterStats.description })
+          .from(characterStats)
+          .where(eq(characterStats.id, grant.entityId));
+
+        if (stat) {
+          entityName = stat.name;
+          entityDescription = stat.description;
+        }
+        break;
+
+      case 'family_member':
+        const [member] = await db
+          .select({ name: familyMembers.name, relationship: familyMembers.relationship })
+          .from(familyMembers)
+          .where(eq(familyMembers.id, grant.entityId));
+
+        if (member) {
+          entityName = member.name;
+          entityDescription = member.relationship;
+        }
+        break;
+
+      // Add cases for other entity types as needed
+    }
+
+    grantsWithEntity.push({
+      ...grant,
+      entityName,
+      entityDescription,
+    });
+  }
+
+  return grantsWithEntity;
+}
+
+/**
+ * Get XP summary by entity type for a user
+ */
+export async function getXpSummaryByEntityType(userId: string): Promise<Record<XpEntityType, number>> {
+  const grants = await db
+    .select({
+      entityType: xpGrants.entityType,
+      totalXp: sql<number>`SUM(${xpGrants.xpAmount})`,
+    })
+    .from(xpGrants)
+    .where(eq(xpGrants.userId, userId))
+    .groupBy(xpGrants.entityType);
+
+  const summary: Record<string, number> = {};
+  for (const grant of grants) {
+    summary[grant.entityType] = grant.totalXp || 0;
+  }
+
+  return summary as Record<XpEntityType, number>;
+}
+
+/**
+ * Get XP breakdown by source type for a specific entity
+ */
+export async function getXpBreakdownBySource(userId: string, entityType: XpEntityType, entityId: string): Promise<Record<XpSourceType, number>> {
+  const grants = await db
+    .select({
+      sourceType: xpGrants.sourceType,
+      totalXp: sql<number>`SUM(${xpGrants.xpAmount})`,
+    })
+    .from(xpGrants)
+    .where(and(eq(xpGrants.userId, userId), eq(xpGrants.entityType, entityType), eq(xpGrants.entityId, entityId)))
+    .groupBy(xpGrants.sourceType);
+
+  const breakdown: Record<string, number> = {};
+  for (const grant of grants) {
+    breakdown[grant.sourceType] = grant.totalXp || 0;
+  }
+
+  return breakdown as Record<XpSourceType, number>;
+}

--- a/copilot/roadmap.md
+++ b/copilot/roadmap.md
@@ -52,6 +52,7 @@
   - “What earned me XP in Strength this week?”
 
 - [ ] **Family Interactions from Journal**
+  - Generic journal interaction table
   - Extract out family interactions from journal
 
 - [ ] **Goal interactions from journal**

--- a/copilot/tasks-prd-gamified-life-app.md
+++ b/copilot/tasks-prd-gamified-life-app.md
@@ -41,16 +41,16 @@
   - [ ] 5.5 Ensure all todo tests pass
 
 - [ ] 6.0 XP & Leveling System (Task Completion, Manual Level Up)
-  - [ ] 6.1 Implement XP grant on task completion (backend)
-  - [ ] 6.2 Implement manual level up logic (backend)
-  - [ ] 6.3 Write backend integration tests for XP/leveling
+  - [x] 6.1 Implement XP grant on task completion (backend)
+  - [x] 6.2 Implement manual level up logic (backend)
+  - [x] 6.3 Write backend integration tests for XP/leveling
   - [ ] 6.4 Implement frontend XP/level up UI
   - [ ] 6.5 Write frontend E2E tests for XP/leveling
   - [ ] 6.6 Ensure all XP/leveling tests pass
 
 - [ ] 7.0 Conversational Journal (Entry, Questions, Saving)
-  - [ ] 7.1 Design and implement journal entry system (backend)
-  - [ ] 7.2 Write backend integration tests for journaling
+  - [x] 7.1 Design and implement journal entry system (backend)
+  - [x] 7.2 Write backend integration tests for journaling
   - [ ] 7.3 Implement frontend conversational journal UI
   - [ ] 7.4 Write frontend E2E tests for journaling
   - [ ] 7.5 Ensure all journal tests pass
@@ -110,3 +110,4 @@
 - Data relationships: Use loose lookups, avoid cascading deletes.
 - UI/UX: Optimize for INTJ + ADHD personas (clarity, feedback, minimal distraction).
 - Out of scope: Third-party task sync, negative XP, monetization, social features.
+- **XP System:** Abstracted character_stat_xp_grants to generic xp_grants table supporting multiple entity types (character_stat, family_member, goal, project, adventure).

--- a/frontend/src/lib/api/stats.ts
+++ b/frontend/src/lib/api/stats.ts
@@ -1,4 +1,10 @@
 import { authenticatedClient } from '../api';
+import type { XpGrant as XpGrantBackend } from '../../../../backend/src/types/xp';
+
+// Serialized version of XpGrant for API responses (Date becomes string)
+export type XpGrantResponse = Omit<XpGrantBackend, 'createdAt'> & {
+  createdAt: string;
+};
 
 // Local type definitions (should match backend types)
 export interface CharacterStatExampleActivity {
@@ -304,7 +310,7 @@ export const statsApi = {
   },
 
   // Get XP history for a stat
-  async getXpHistory(statId: string, limit = 50, offset = 0): Promise<CharacterStatXpGrant[]> {
+  async getXpHistory(statId: string, limit = 50, offset = 0): Promise<XpGrantResponse[]> {
     try {
       const response = await authenticatedClient.api.stats[':id']['xp-history'].$get({
         param: { id: statId },
@@ -317,7 +323,7 @@ export const statsApi = {
         throw new Error((result as any).error || `Error ${response.status}: ${response.statusText}`);
       }
 
-      const result = (await response.json()) as ApiResponse<CharacterStatXpGrant[]>;
+      const result = (await response.json()) as ApiResponse<XpGrantResponse[]>;
       return result.data;
     } catch (error) {
       console.error('Get XP history API request failed:', error);

--- a/frontend/src/routes/stats/[id]/+page.svelte
+++ b/frontend/src/routes/stats/[id]/+page.svelte
@@ -6,11 +6,11 @@
   import { statsApi } from '$lib/api/stats.js';
   import { Trophy, TrendingUp, Calendar, Zap, Edit, Trash2, BarChart3, Award, Target, Activity } from 'lucide-svelte';
 
-  import type { CharacterStatXpGrant, CharacterStatWithProgress } from '$lib/api/stats';
+  import type { XpGrantResponse, CharacterStatWithProgress } from '$lib/api/stats';
 
   // State
   let stat = $state<CharacterStatWithProgress | null>(null);
-  let xpHistory = $state<CharacterStatXpGrant[]>([]);
+  let xpHistory = $state<XpGrantResponse[]>([]);
   let loading = $state(true);
   let error = $state<string | null>(null);
   let showDeleteModal = $state(false);


### PR DESCRIPTION
Introduce a generic XP grants system that supports multiple entity types, replacing the previous character_stat_xp_grants table. Update frontend components to reflect these changes and ensure tasks can be marked complete with XP awarded accordingly.