### PR TITLE
Use local dates for experiments

### DIFF
--- a/backend/src/routes/experiments.ts
+++ b/backend/src/routes/experiments.ts
@@ -287,7 +287,7 @@ const app = new Hono()
           .orderBy(desc(experimentTaskCompletions.completedDate));
 
         // Check if completed today
-        const today = new Date().toISOString().split('T')[0];
+        const today = new Date().toLocaleDateString('en-CA');
         const isCompleteToday = completions.some((c) => c.completedDate === today);
 
         tasksWithCompletions.push({
@@ -605,7 +605,7 @@ const app = new Hono()
           )
           .orderBy(desc(experimentTaskCompletions.completedDate));
 
-        const today = new Date().toISOString().split('T')[0];
+        const today = new Date().toLocaleDateString('en-CA');
         const isCompleteToday = completions.some((c) => c.completedDate === today);
 
         totalTaskCompletions += completions.length;

--- a/frontend/src/lib/components/experiments/ExperimentTasksWidget.svelte
+++ b/frontend/src/lib/components/experiments/ExperimentTasksWidget.svelte
@@ -26,7 +26,7 @@
       const experiments = await experimentsApi.getUserExperiments();
 
       // Filter for active experiments (experiments happening today)
-      const today = new Date().toISOString().split('T')[0];
+      const today = new Date().toLocaleDateString('en-CA');
       const active = experiments.filter((exp) => {
         return exp.startDate <= today && exp.endDate >= today;
       });
@@ -65,7 +65,7 @@
 
   async function completeTask(experimentId: string, taskId: string) {
     try {
-      const today = new Date().toISOString().split('T')[0];
+      const today = new Date().toLocaleDateString('en-CA');
 
       await experimentsApi.completeExperimentTask(experimentId, taskId, {
         completedDate: today,

--- a/frontend/src/routes/experiments/+page.svelte
+++ b/frontend/src/routes/experiments/+page.svelte
@@ -38,7 +38,7 @@
 
   // Helper functions
   function getExperimentStatus(experiment: ExperimentResponse): 'upcoming' | 'active' | 'completed' {
-    const today = new Date().toISOString().split('T')[0];
+    const today = new Date().toLocaleDateString('en-CA');
     const startDate = experiment.startDate;
     const endDate = experiment.endDate;
 

--- a/frontend/src/routes/experiments/[id]/+page.svelte
+++ b/frontend/src/routes/experiments/[id]/+page.svelte
@@ -60,7 +60,7 @@
 
   // Helper functions
   function getExperimentStatus(exp: ExperimentWithTasksResponse): 'upcoming' | 'active' | 'completed' {
-    const today = new Date().toISOString().split('T')[0];
+    const today = new Date().toLocaleDateString('en-CA');
     const startDate = exp.startDate;
     const endDate = exp.endDate;
 

--- a/frontend/src/routes/experiments/[id]/dashboard/+page.svelte
+++ b/frontend/src/routes/experiments/[id]/dashboard/+page.svelte
@@ -40,7 +40,7 @@
 
   // Helper functions
   function getExperimentStatus(exp: ExperimentDashboardResponse['experiment']): 'upcoming' | 'active' | 'completed' {
-    const today = new Date().toISOString().split('T')[0];
+    const today = new Date().toLocaleDateString('en-CA');
     const startDate = exp.startDate;
     const endDate = exp.endDate;
 


### PR DESCRIPTION
Replace the ISO date format with the Canadian locale date format for better alignment with local date representation in experiment-related functionalities.