### PR TITLE
Integrate journal entries into experiment dashboard

### DIFF
--- a/backend/src/tests/experiments.test.ts
+++ b/backend/src/tests/experiments.test.ts
@@ -500,6 +500,8 @@ describe('Experiments API Integration Tests', () => {
       expect(dashboard.xpBreakdown.fromTasks).toBe(5);
       expect(dashboard.tasks).toHaveLength(1);
       expect(dashboard.tasks[0].completionCount).toBe(1);
+      expect(dashboard.journalEntries).toBeDefined();
+      expect(Array.isArray(dashboard.journalEntries)).toBe(true);
     });
   });
 

--- a/backend/src/types/experiments.ts
+++ b/backend/src/types/experiments.ts
@@ -80,13 +80,13 @@ export type ExperimentDashboardResponse = {
     totalTaskInstances: number;
   };
   tasks: ExperimentTaskWithCompletionsResponse[];
-  // TODO: Uncomment when journal entries are available
-  // journalEntries: Array<{
-  //   id: string;
-  //   title: string;
-  //   synopsis: string;
-  //   createdAt: string;
-  // }>;
+  journalEntries: Array<{
+    id: string;
+    title: string | null;
+    synopsis: string | null;
+    createdAt: string;
+    date: string;
+  }>;
   xpBreakdown: {
     fromTasks: number;
     fromJournals: number;

--- a/frontend/src/lib/components/journal/JournalComplete.svelte
+++ b/frontend/src/lib/components/journal/JournalComplete.svelte
@@ -212,11 +212,11 @@
       <div class="grid grid-cols-1 gap-4 text-sm sm:grid-cols-2">
         <div>
           <span class="text-base-content/70 font-medium">Created:</span>
-          <span class="ml-2">{formatDate(journal.createdAt)}</span>
+          <span class="ml-2">{formatDateTime(journal.createdAt)}</span>
         </div>
         <div>
           <span class="text-base-content/70 font-medium">Completed:</span>
-          <span class="ml-2">{formatDate(journal.updatedAt)}</span>
+          <span class="ml-2">{formatDateTime(journal.updatedAt)}</span>
         </div>
         <div>
           <span class="text-base-content/70 font-medium">Messages:</span>

--- a/frontend/src/routes/experiments/[id]/dashboard/+page.svelte
+++ b/frontend/src/routes/experiments/[id]/dashboard/+page.svelte
@@ -194,8 +194,7 @@
 
         <div class="card bg-base-100 border-base-300 border">
           <div class="card-body text-center">
-            <!-- TODO - add back -->
-            <!-- <div class="text-warning text-3xl font-bold">{dashboard.journalEntries.length}</div> -->
+            <div class="text-warning text-3xl font-bold">{dashboard.journalEntries.length}</div>
             <div class="text-base-content/60 text-sm">Journal Entries</div>
             <div class="text-base-content/40 text-xs">during experiment</div>
           </div>
@@ -277,23 +276,22 @@
               Journal Entries
             </h2>
 
-            <!-- TODO - add back -->
-            <!-- {#if dashboard.journalEntries.length > 0}
+            {#if dashboard.journalEntries.length > 0}
               <div class="space-y-4">
                 {#each dashboard.journalEntries as entry}
                   <div class="card bg-base-200 border-base-300 border">
                     <div class="card-body p-4">
                       <div class="flex items-start justify-between">
                         <div class="flex-1">
-                          <h3 class="text-base-content mb-1 font-semibold">{entry.title}</h3>
+                          <h3 class="text-base-content mb-1 font-semibold">{entry.title || 'Untitled Entry'}</h3>
                           {#if entry.synopsis}
                             <p class="text-base-content/60 mb-2 line-clamp-2 text-sm">{entry.synopsis}</p>
                           {/if}
                           <div class="text-base-content/40 text-xs">
-                            {formatDate(entry.createdAt)}
+                            {formatDate(entry.date)}
                           </div>
                         </div>
-                        <a href="/journal/{entry.id}" class="btn btn-ghost btn-sm" title="View entry"> View </a>
+                        <a href="/journal/{entry.date}" class="btn btn-ghost btn-sm" title="View entry"> View </a>
                       </div>
                     </div>
                   </div>
@@ -310,12 +308,12 @@
                 <Book class="text-base-content/30 mx-auto mb-4 h-12 w-12" />
                 <h3 class="text-base-content mb-2 text-lg font-medium">No journal entries</h3>
                 <p class="text-base-content/60 mb-4">Write about your experiment experience to track insights and progress.</p>
-                <a href="/journal/longform" class="btn btn-secondary btn-sm">
+                <a href="/journal" class="btn btn-secondary btn-sm">
                   <Book class="h-4 w-4" />
                   Start Journaling
                 </a>
               </div>
-            {/if} -->
+            {/if}
           </div>
         </div>
       </div>


### PR DESCRIPTION
Fetch and display journal entries related to experiments, ensuring only completed entries are included. Update the dashboard to reflect these changes and improve the user interface for better clarity.