### PR TITLE
Refactor date handling in journal navigation

### DIFF
--- a/frontend/src/lib/api/journal.ts
+++ b/frontend/src/lib/api/journal.ts
@@ -17,24 +17,24 @@ export class JournalService {
   static async getTodaysJournal(): Promise<TodayJournalResponse> {
     // Get today's date in YYYY-MM-DD format using browser timezone
     const todayDate = getTodayDateString();
-    
+
     try {
       // Use the date-specific endpoint
       const response = await apiFetch(`/api/journals/${todayDate}`);
       const journalData = response.data;
-      
+
       // Transform JournalResponse to TodayJournalResponse
       return {
         exists: true,
         journal: journalData,
         status: journalData.status,
-        actionText: this.getActionTextBasedOnStatus(journalData.status)
+        actionText: this.getActionTextBasedOnStatus(journalData.status),
       };
     } catch (error) {
       // If no journal exists for today (404 error)
       return {
         exists: false,
-        actionText: 'Write Journal'
+        actionText: 'Write Journal',
       };
     }
   }
@@ -46,7 +46,7 @@ export class JournalService {
     const response = await apiFetch(`/api/journals/${date}`);
     return response.data;
   }
-  
+
   /**
    * Helper to determine the appropriate action text based on journal status
    */

--- a/frontend/src/lib/components/journal/JournalCalendarHeatmap.svelte
+++ b/frontend/src/lib/components/journal/JournalCalendarHeatmap.svelte
@@ -79,14 +79,6 @@
     goto(`/journal/${date}`);
   }
 
-  // Format date for display
-  function formatDateLabel(date: string): string {
-    return new Date(date).toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-    });
-  }
-
   // Get month labels for the current view
   function getMonthLabels(): Array<{ month: string; position: number }> {
     const labels = [];

--- a/frontend/src/lib/components/journal/JournalWidget.svelte
+++ b/frontend/src/lib/components/journal/JournalWidget.svelte
@@ -73,13 +73,13 @@
         <!-- Date Display -->
         <div class="text-base-content/70 flex items-center gap-2">
           <CalendarIcon size={16} />
-            <span class="text-sm">
+          <span class="text-sm">
             {#if todayJournal?.journal?.date}
               {formatDate(todayJournal.journal.date)}
             {:else}
               {getNowDateTimeString('date-only')}
             {/if}
-            </span>
+          </span>
         </div>
 
         <!-- Status Display -->

--- a/frontend/src/lib/utils/date.ts
+++ b/frontend/src/lib/utils/date.ts
@@ -93,13 +93,13 @@ export function getNowDateTimeString(
     const options: Intl.DateTimeFormatOptions = {
       year: 'numeric',
       month: '2-digit',
-      day: '2-digit'
+      day: '2-digit',
     };
-    
+
     if (timezone !== 'local') {
       options.timeZone = timezone;
     }
-    
+
     return new Intl.DateTimeFormat('en-CA', options).format(now);
   }
 

--- a/frontend/src/routes/journal/+page.svelte
+++ b/frontend/src/routes/journal/+page.svelte
@@ -7,7 +7,7 @@
   import JournalCard from '$lib/components/journal/JournalCard.svelte';
   import JournalFilterBar from '$lib/components/journal/JournalFilterBar.svelte';
   import JournalCalendarHeatmap from '$lib/components/journal/JournalCalendarHeatmap.svelte';
-
+  import { getTodayDateString } from '$lib/utils/date';
   // State
   let journals: JournalListItem[] = [];
   let totalJournals = 0;
@@ -83,7 +83,7 @@
   }
 
   function createNewJournal() {
-    goto(`/journal/${JournalService.getTodayDate()}`);
+    goto(`/journal/${getTodayDateString()}`);
   }
 
   function toggleViewMode() {

--- a/frontend/src/routes/journal/[date]/+page.svelte
+++ b/frontend/src/routes/journal/[date]/+page.svelte
@@ -9,7 +9,7 @@
   import JournalChat from '$lib/components/journal/JournalChat.svelte';
   import JournalComplete from '$lib/components/journal/JournalComplete.svelte';
   import { BookIcon, CalendarIcon, ArrowLeftIcon } from 'lucide-svelte';
-
+  import { getTodayDateString } from '$lib/utils/date';
   // Get date from URL params
   $: date = $page.params.date;
 
@@ -19,7 +19,7 @@
 
   onMount(async () => {
     if (!date) {
-      goto('/journal/' + JournalService.getTodayDate());
+      goto('/journal/' + getTodayDateString());
       return;
     }
 
@@ -58,7 +58,7 @@
   }
 
   function goToToday() {
-    goto('/journal/' + JournalService.getTodayDate());
+    goto('/journal/' + getTodayDateString());
   }
 
   function goBack() {


### PR DESCRIPTION
Replace direct calls to `JournalService.getTodayDate()` with a utility function `getTodayDateString()` for improved date handling and consistency across the journal navigation. Clean up unused date formatting function.