### PR TITLE
Fix HTML tag linting and mark experiment as done

### DIFF
--- a/copilot/roadmap.md
+++ b/copilot/roadmap.md
@@ -65,7 +65,7 @@
 
 ### 🗺️ Phase 3: Experiments & Tasks (Weeks 5–6)
 
-- [ ] **Experiments**
+- [x] **Experiments**
   - Create/edit short-lived experiments
   - Daily task generation
   - Journal and XP dashboard for each experiment
@@ -76,6 +76,8 @@
   - Manual log of repeatable activities tied to stats (e.g. “Workout”)
   - Grants XP to associated stat
   - Logged in a separate tab (not dashboard)
+
+- [ ] Create red -> green heatmap from journal entries
 
 - [ ] **Dungeon Master GPT Task Generator**
   - Use character, goals, focus, family, weather, projects/adventures, past tasks

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -42,8 +42,7 @@ export default ts.config(
       // Other rules are still at warning level for now
       '@typescript-eslint/no-explicit-any': 'off',
       '@typescript-eslint/no-unused-vars': 'off',
-      'svelte/require-each-key': 'warn',
-      'svelte/no-at-html-tags': 'off', // Disabled for markdown content with proper sanitization
+      'svelte/require-each-key': 'warn'
     },
   },
   {

--- a/frontend/src/lib/components/experiments/ExperimentTasksWidget.svelte
+++ b/frontend/src/lib/components/experiments/ExperimentTasksWidget.svelte
@@ -198,6 +198,7 @@
                   {experiment.title}
                 </h4>
                 {#if experiment.description}
+                  <!-- eslint-disable-next-line svelte/no-at-html-tags -->
                   <p class="text-base-content/70 prose prose-sm mt-1 text-sm">{@html DOMPurify.sanitize(String(marked.parse(experiment.description)))}</p>
                 {/if}
               </div>

--- a/frontend/src/lib/components/journal/JournalChat.svelte
+++ b/frontend/src/lib/components/journal/JournalChat.svelte
@@ -144,6 +144,7 @@
             <!-- Message Content -->
             <div class="max-w-[75%] flex-1 sm:max-w-md lg:max-w-lg {message.role === 'user' ? 'text-right' : ''}">
               <div class="rounded-lg px-3 py-2 sm:px-4 sm:py-3 {message.role === 'user' ? 'bg-primary text-primary-content' : 'bg-base-200 text-base-content'}">
+                <!-- eslint-disable-next-line svelte/no-at-html-tags -->
                 <p class="prose prose-sm text-xs leading-relaxed sm:text-sm">{@html DOMPurify.sanitize(String(marked.parse(message.content)))}</p>
               </div>
 

--- a/frontend/src/lib/components/journal/JournalComplete.svelte
+++ b/frontend/src/lib/components/journal/JournalComplete.svelte
@@ -60,6 +60,7 @@
         </div>
 
         <div class="prose prose-sm max-w-none">
+          <!-- eslint-disable-next-line svelte/no-at-html-tags -->
           <p class="text-base-content/90 prose prose-sm leading-relaxed">{@html DOMPurify.sanitize(String(marked.parse(journal.summary)))}</p>
         </div>
       </div>
@@ -174,6 +175,7 @@
               <!-- Message Content -->
               <div class="max-w-md flex-1 {message.role === 'user' ? 'text-right' : ''}">
                 <div class="rounded-lg px-4 py-3 {message.role === 'user' ? 'bg-primary/10 border-primary/20 border' : 'bg-base-200'}">
+                  <!-- eslint-disable-next-line svelte/no-at-html-tags -->
                   <p class="prose prose-sm text-sm leading-relaxed">{@html DOMPurify.sanitize(String(marked.parse(message.content)))}</p>
                 </div>
 

--- a/frontend/src/routes/character/CharacterView.svelte
+++ b/frontend/src/routes/character/CharacterView.svelte
@@ -537,6 +537,7 @@
                   Backstory
                 </h3>
                 <div class="prose prose-sm max-w-none text-left leading-relaxed">
+                  <!-- eslint-disable-next-line svelte/no-at-html-tags -->
                   {@html DOMPurify.sanitize(String(marked.parse(character.backstory)))}
                 </div>
               </div>
@@ -564,6 +565,7 @@
                   Goals & Aspirations
                 </h3>
                 <div class="prose prose-sm max-w-none text-left leading-relaxed">
+                  <!-- eslint-disable-next-line svelte/no-at-html-tags -->
                   {@html DOMPurify.sanitize(String(marked.parse(character.goals)))}
                 </div>
               </div>

--- a/frontend/src/routes/experiments/+page.svelte
+++ b/frontend/src/routes/experiments/+page.svelte
@@ -179,6 +179,7 @@
                     <div class="flex-1">
                       <h3 class="card-title text-base-content">{experiment.title}</h3>
                       {#if experiment.description}
+                        <!-- eslint-disable-next-line svelte/no-at-html-tags -->
                         <p class="text-base-content/60 prose prose-sm mb-3 text-sm">{@html DOMPurify.sanitize(String(marked.parse(experiment.description)))}</p>
                       {/if}
                     </div>
@@ -232,6 +233,7 @@
                     <div class="flex-1">
                       <h3 class="card-title text-base-content">{experiment.title}</h3>
                       {#if experiment.description}
+                        <!-- eslint-disable-next-line svelte/no-at-html-tags -->
                         <p class="text-base-content/60 prose prose-sm mb-3 text-sm">{@html DOMPurify.sanitize(String(marked.parse(experiment.description)))}</p>
                       {/if}
                     </div>
@@ -285,6 +287,7 @@
                     <div class="flex-1">
                       <h3 class="card-title text-base-content">{experiment.title}</h3>
                       {#if experiment.description}
+                        <!-- eslint-disable-next-line svelte/no-at-html-tags -->
                         <p class="text-base-content/60 prose prose-sm mb-3 text-sm">{@html DOMPurify.sanitize(String(marked.parse(experiment.description)))}</p>
                       {/if}
                     </div>

--- a/frontend/src/routes/experiments/[id]/+page.svelte
+++ b/frontend/src/routes/experiments/[id]/+page.svelte
@@ -180,6 +180,7 @@
 
               {#if dashboard.experiment.description}
                 <p class="text-base-content/70 prose prose-sm mb-4 text-lg">
+                  <!-- eslint-disable-next-line svelte/no-at-html-tags -->
                   {@html DOMPurify.sanitize(String(marked.parse(dashboard.experiment.description)))}
                 </p>
               {/if}

--- a/frontend/src/routes/goals/+page.svelte
+++ b/frontend/src/routes/goals/+page.svelte
@@ -174,6 +174,7 @@
                       </div>
 
                       {#if goal.description}
+                        <!-- eslint-disable-next-line svelte/no-at-html-tags -->
                         <p class="text-base-content/80 prose prose-sm mb-4 text-sm">{@html DOMPurify.sanitize(String(marked.parse(goal.description)))}</p>
                       {/if}
 


### PR DESCRIPTION
Disable the linting rule for HTML tags in Svelte components to accommodate markdown content, and mark the experiment section as completed.