### PR TITLE
Add weekly and monthly journal summaries feature

### DIFF
--- a/backend/src/db/migrations/0026_new_impossible_man.sql
+++ b/backend/src/db/migrations/0026_new_impossible_man.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "journal_summaries" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"period" varchar(10) NOT NULL,
+	"start_date" date NOT NULL,
+	"end_date" date NOT NULL,
+	"summary" text NOT NULL,
+	"tags" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "journal_summaries" ADD CONSTRAINT "journal_summaries_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;

--- a/backend/src/db/migrations/meta/0026_snapshot.json
+++ b/backend/src/db/migrations/meta/0026_snapshot.json
@@ -1,0 +1,1875 @@
+{
+  "id": "f386b739-3cae-434a-b182-45188db7e2e5",
+  "prevId": "3a540fea-f8d0-47b0-873f-a89d2392229d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.characters": {
+      "name": "characters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_class": {
+          "name": "character_class",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backstory": {
+          "name": "backstory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goals": {
+          "name": "goals",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "motto": {
+          "name": "motto",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "characters_user_id_users_id_fk": {
+          "name": "characters_user_id_users_id_fk",
+          "tableFrom": "characters",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.character_stat_level_titles": {
+      "name": "character_stat_level_titles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "stat_id": {
+          "name": "stat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "character_stat_level_titles_stat_id_character_stats_id_fk": {
+          "name": "character_stat_level_titles_stat_id_character_stats_id_fk",
+          "tableFrom": "character_stat_level_titles",
+          "tableTo": "character_stats",
+          "columnsFrom": [
+            "stat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.character_stats": {
+      "name": "character_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "example_activities": {
+          "name": "example_activities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "current_level": {
+          "name": "current_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "total_xp": {
+          "name": "total_xp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "character_stats_user_id_users_id_fk": {
+          "name": "character_stats_user_id_users_id_fk",
+          "tableFrom": "character_stats",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.xp_grants": {
+      "name": "xp_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "xp_amount": {
+          "name": "xp_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "xp_grants_user_id_users_id_fk": {
+          "name": "xp_grants_user_id_users_id_fk",
+          "tableFrom": "xp_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.goals": {
+      "name": "goals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "goals_user_id_users_id_fk": {
+          "name": "goals_user_id_users_id_fk",
+          "tableFrom": "goals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.family_members": {
+      "name": "family_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relationship": {
+          "name": "relationship",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birthday": {
+          "name": "birthday",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "likes": {
+          "name": "likes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dislikes": {
+          "name": "dislikes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_interaction_date": {
+          "name": "last_interaction_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection_xp": {
+          "name": "connection_xp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "connection_level": {
+          "name": "connection_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "family_members_user_id_users_id_fk": {
+          "name": "family_members_user_id_users_id_fk",
+          "tableFrom": "family_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.family_task_feedback": {
+      "name": "family_task_feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "family_member_id": {
+          "name": "family_member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_description": {
+          "name": "task_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enjoyed_it": {
+          "name": "enjoyed_it",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "xp_granted": {
+          "name": "xp_granted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "family_task_feedback_user_id_users_id_fk": {
+          "name": "family_task_feedback_user_id_users_id_fk",
+          "tableFrom": "family_task_feedback",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "family_task_feedback_family_member_id_family_members_id_fk": {
+          "name": "family_task_feedback_family_member_id_family_members_id_fk",
+          "tableFrom": "family_task_feedback",
+          "tableTo": "family_members",
+          "columnsFrom": [
+            "family_member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.goal_tags": {
+      "name": "goal_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "goal_id": {
+          "name": "goal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "goal_tags_goal_id_goals_id_fk": {
+          "name": "goal_tags_goal_id_goals_id_fk",
+          "tableFrom": "goal_tags",
+          "tableTo": "goals",
+          "columnsFrom": [
+            "goal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "goal_tags_tag_id_tags_id_fk": {
+          "name": "goal_tags_tag_id_tags_id_fk",
+          "tableFrom": "goal_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tags_user_id_users_id_fk": {
+          "name": "tags_user_id_users_id_fk",
+          "tableFrom": "tags",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_tag": {
+          "name": "unique_user_tag",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.focuses": {
+      "name": "focuses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "focuses_user_id_users_id_fk": {
+          "name": "focuses_user_id_users_id_fk",
+          "tableFrom": "focuses",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simple_todos": {
+      "name": "simple_todos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_completed": {
+          "name": "is_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiration_time": {
+          "name": "expiration_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "simple_todos_user_id_users_id_fk": {
+          "name": "simple_todos_user_id_users_id_fk",
+          "tableFrom": "simple_todos",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.experiment_task_completions": {
+      "name": "experiment_task_completions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_date": {
+          "name": "completed_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "experiment_task_completions_task_id_experiment_tasks_id_fk": {
+          "name": "experiment_task_completions_task_id_experiment_tasks_id_fk",
+          "tableFrom": "experiment_task_completions",
+          "tableTo": "experiment_tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "experiment_task_completions_user_id_users_id_fk": {
+          "name": "experiment_task_completions_user_id_users_id_fk",
+          "tableFrom": "experiment_task_completions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.experiment_tasks": {
+      "name": "experiment_tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "experiment_id": {
+          "name": "experiment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stat_id": {
+          "name": "stat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success_metric": {
+          "name": "success_metric",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "xp_reward": {
+          "name": "xp_reward",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "experiment_tasks_experiment_id_experiments_id_fk": {
+          "name": "experiment_tasks_experiment_id_experiments_id_fk",
+          "tableFrom": "experiment_tasks",
+          "tableTo": "experiments",
+          "columnsFrom": [
+            "experiment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "experiment_tasks_stat_id_character_stats_id_fk": {
+          "name": "experiment_tasks_stat_id_character_stats_id_fk",
+          "tableFrom": "experiment_tasks",
+          "tableTo": "character_stats",
+          "columnsFrom": [
+            "stat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.experiments": {
+      "name": "experiments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reflection": {
+          "name": "reflection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "should_repeat": {
+          "name": "should_repeat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "experiments_user_id_users_id_fk": {
+          "name": "experiments_user_id_users_id_fk",
+          "tableFrom": "experiments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.journals": {
+      "name": "journals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "initial_message": {
+          "name": "initial_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_session": {
+          "name": "chat_session",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synopsis": {
+          "name": "synopsis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "day_rating": {
+          "name": "day_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inferred_day_rating": {
+          "name": "inferred_day_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "journals_user_id_users_id_fk": {
+          "name": "journals_user_id_users_id_fk",
+          "tableFrom": "journals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.journal_summaries": {
+      "name": "journal_summaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period": {
+          "name": "period",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "journal_summaries_user_id_users_id_fk": {
+          "name": "journal_summaries_user_id_users_id_fk",
+          "tableFrom": "journal_summaries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quest_experiments": {
+      "name": "quest_experiments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "quest_id": {
+          "name": "quest_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "experiment_id": {
+          "name": "experiment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "quest_experiments_quest_id_quests_id_fk": {
+          "name": "quest_experiments_quest_id_quests_id_fk",
+          "tableFrom": "quest_experiments",
+          "tableTo": "quests",
+          "columnsFrom": [
+            "quest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "quest_experiments_experiment_id_experiments_id_fk": {
+          "name": "quest_experiments_experiment_id_experiments_id_fk",
+          "tableFrom": "quest_experiments",
+          "tableTo": "experiments",
+          "columnsFrom": [
+            "experiment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quest_journals": {
+      "name": "quest_journals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "quest_id": {
+          "name": "quest_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "journal_id": {
+          "name": "journal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linked_type": {
+          "name": "linked_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'automatic'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "quest_journals_quest_id_quests_id_fk": {
+          "name": "quest_journals_quest_id_quests_id_fk",
+          "tableFrom": "quest_journals",
+          "tableTo": "quests",
+          "columnsFrom": [
+            "quest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "quest_journals_journal_id_journals_id_fk": {
+          "name": "quest_journals_journal_id_journals_id_fk",
+          "tableFrom": "quest_journals",
+          "tableTo": "journals",
+          "columnsFrom": [
+            "journal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quests": {
+      "name": "quests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reflection": {
+          "name": "reflection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "quests_user_id_users_id_fk": {
+          "name": "quests_user_id_users_id_fk",
+          "tableFrom": "quests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plan_subtasks": {
+      "name": "plan_subtasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_completed": {
+          "name": "is_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "plan_subtasks_plan_id_plans_id_fk": {
+          "name": "plan_subtasks_plan_id_plans_id_fk",
+          "tableFrom": "plan_subtasks",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "plan_subtasks_user_id_users_id_fk": {
+          "name": "plan_subtasks_user_id_users_id_fk",
+          "tableFrom": "plan_subtasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plans": {
+      "name": "plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focus_id": {
+          "name": "focus_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_ordered": {
+          "name": "is_ordered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "plans_user_id_users_id_fk": {
+          "name": "plans_user_id_users_id_fk",
+          "tableFrom": "plans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "plans_focus_id_focuses_id_fk": {
+          "name": "plans_focus_id_focuses_id_fk",
+          "tableFrom": "plans",
+          "tableTo": "focuses",
+          "columnsFrom": [
+            "focus_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/src/db/migrations/meta/_journal.json
+++ b/backend/src/db/migrations/meta/_journal.json
@@ -183,6 +183,13 @@
       "when": 1752942873806,
       "tag": "0025_soft_dagger",
       "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "7",
+      "when": 1752957825079,
+      "tag": "0026_new_impossible_man",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/db/schema/index.ts
+++ b/backend/src/db/schema/index.ts
@@ -9,6 +9,7 @@ export * from './focus';
 export * from './todos';
 export * from './experiments';
 export * from './journals';
+export * from './journal-summaries';
 export * from './quests';
 export * from './plans';
 // Future exports:

--- a/backend/src/db/schema/journal-summaries.ts
+++ b/backend/src/db/schema/journal-summaries.ts
@@ -1,0 +1,16 @@
+import { pgTable, uuid, varchar, text, date, timestamp, jsonb } from 'drizzle-orm/pg-core';
+import { users } from './users';
+
+export const journalSummaries = pgTable('journal_summaries', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  userId: uuid('user_id')
+    .notNull()
+    .references(() => users.id, { onDelete: 'cascade' }),
+  period: varchar('period', { length: 10 }).notNull(), // 'week' | 'month'
+  startDate: date('start_date').notNull(), // Saturday for weeks, 1st of month for months
+  endDate: date('end_date').notNull(), // Friday for weeks, last day of month
+  summary: text('summary').notNull(), // Generated long-form summary (used for GPT context)
+  tags: jsonb('tags'), // Optional: top tags extracted from entries (string[])
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+});

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -12,6 +12,7 @@ import focusRoutes from './routes/focus';
 import todosRoutes from './routes/todos';
 import experimentsRoutes from './routes/experiments';
 import journalsRoutes from './routes/journals';
+import journalSummariesRoutes from './routes/journal-summaries';
 import questsRoutes from './routes/quests';
 import plansRoutes from './routes/plans';
 import xpGrantsRoutes from './routes/xpGrants';
@@ -65,6 +66,8 @@ const routes = app
   .route('/api/experiments', experimentsRoutes)
   // Mount journal routes
   .route('/api/journals', journalsRoutes)
+  // Mount journal summaries routes
+  .route('/api/journal-summaries', journalSummariesRoutes)
   // Mount quest routes
   .route('/api/quests', questsRoutes)
   // Mount plans routes

--- a/backend/src/routes/journal-summaries.ts
+++ b/backend/src/routes/journal-summaries.ts
@@ -1,0 +1,350 @@
+import { Hono } from 'hono';
+import { zValidator } from '@hono/zod-validator';
+import { eq, and, gte, lte, desc, count } from 'drizzle-orm';
+import { jwtAuth, getUserId } from '../middleware/auth';
+import { db } from '../db';
+import { journalSummaries, journals } from '../db/schema';
+import {
+  createJournalSummarySchema,
+  updateJournalSummarySchema,
+  listJournalSummariesSchema,
+  journalSummaryIdSchema,
+  generateJournalSummarySchema,
+} from '../validation/journal-summaries';
+import { handleApiError } from '../utils/logger';
+import { generatePeriodSummary } from '../utils/gpt/periodSummary';
+import type {
+  CreateJournalSummaryRequest,
+  UpdateJournalSummaryRequest,
+  ListJournalSummariesRequest,
+  GenerateJournalSummaryRequest,
+  JournalSummaryResponse,
+  ListJournalSummariesResponse,
+} from '../types/journal-summaries';
+
+/**
+ * Helper function to serialize journal summary to response format
+ */
+const serializeJournalSummary = (summary: typeof journalSummaries.$inferSelect): JournalSummaryResponse => {
+  return {
+    id: summary.id,
+    userId: summary.userId,
+    period: summary.period as 'week' | 'month',
+    startDate: summary.startDate,
+    endDate: summary.endDate,
+    summary: summary.summary,
+    tags: summary.tags as string[] | null,
+    createdAt: summary.createdAt.toISOString(),
+    updatedAt: summary.updatedAt.toISOString(),
+  };
+};
+
+// Chain methods for RPC compatibility
+const app = new Hono()
+  // Get user's journal summaries with filtering
+  .get('/', jwtAuth, zValidator('query', listJournalSummariesSchema), async (c) => {
+    try {
+      const userId = getUserId(c);
+      const filters = c.req.valid('query') as ListJournalSummariesRequest;
+
+      // Build where conditions
+      const conditions = [eq(journalSummaries.userId, userId)];
+
+      if (filters.period) {
+        conditions.push(eq(journalSummaries.period, filters.period));
+      }
+
+      if (filters.year) {
+        // Filter by year in startDate
+        const yearStart = `${filters.year}-01-01`;
+        const yearEnd = `${filters.year}-12-31`;
+        conditions.push(gte(journalSummaries.startDate, yearStart));
+        conditions.push(lte(journalSummaries.startDate, yearEnd));
+      }
+
+      // Get total count
+      const [{ totalCount }] = await db
+        .select({ totalCount: count() })
+        .from(journalSummaries)
+        .where(and(...conditions));
+
+      // Get summaries with pagination
+      const summaries = await db
+        .select()
+        .from(journalSummaries)
+        .where(and(...conditions))
+        .orderBy(desc(journalSummaries.startDate))
+        .limit(filters.limit || 20)
+        .offset(filters.offset || 0);
+
+      const hasMore = (filters.offset || 0) + (filters.limit || 20) < totalCount;
+
+      const response: ListJournalSummariesResponse = {
+        summaries: summaries.map(serializeJournalSummary),
+        total: totalCount,
+        hasMore,
+      };
+
+      return c.json({
+        success: true,
+        data: response,
+      });
+    } catch (error) {
+      return handleApiError(error, 'Failed to list journal summaries');
+    }
+  })
+
+  // Get specific journal summary by ID
+  .get('/:id', jwtAuth, zValidator('param', journalSummaryIdSchema), async (c) => {
+    try {
+      const userId = getUserId(c);
+      const { id } = c.req.valid('param');
+
+      const summary = await db
+        .select()
+        .from(journalSummaries)
+        .where(and(eq(journalSummaries.id, id), eq(journalSummaries.userId, userId)))
+        .limit(1);
+
+      if (summary.length === 0) {
+        return c.json(
+          {
+            success: false,
+            error: 'Journal summary not found',
+          },
+          404,
+        );
+      }
+
+      return c.json({
+        success: true,
+        data: serializeJournalSummary(summary[0]),
+      });
+    } catch (error) {
+      return handleApiError(error, 'Failed to fetch journal summary');
+    }
+  })
+
+  // Create a new journal summary (manual creation)
+  .post('/', jwtAuth, zValidator('json', createJournalSummarySchema), async (c) => {
+    try {
+      const userId = getUserId(c);
+      const data = c.req.valid('json') as CreateJournalSummaryRequest;
+
+      // Check if summary already exists for this period and date range
+      const existingSummary = await db
+        .select()
+        .from(journalSummaries)
+        .where(
+          and(
+            eq(journalSummaries.userId, userId),
+            eq(journalSummaries.period, data.period),
+            eq(journalSummaries.startDate, data.startDate),
+            eq(journalSummaries.endDate, data.endDate),
+          ),
+        )
+        .limit(1);
+
+      if (existingSummary.length > 0) {
+        return c.json(
+          {
+            success: false,
+            error: 'Journal summary for this period already exists',
+          },
+          409,
+        );
+      }
+
+      const newSummary = await db
+        .insert(journalSummaries)
+        .values({
+          userId,
+          period: data.period,
+          startDate: data.startDate,
+          endDate: data.endDate,
+          summary: data.summary,
+          tags: data.tags || null,
+        })
+        .returning();
+
+      return c.json(
+        {
+          success: true,
+          data: serializeJournalSummary(newSummary[0]),
+        },
+        201,
+      );
+    } catch (error) {
+      return handleApiError(error, 'Failed to create journal summary');
+    }
+  })
+
+  // Generate a journal summary using GPT
+  .post('/generate', jwtAuth, zValidator('json', generateJournalSummarySchema), async (c) => {
+    try {
+      const userId = getUserId(c);
+      const data = c.req.valid('json') as GenerateJournalSummaryRequest;
+
+      // Check if summary already exists for this period and date range
+      const existingSummary = await db
+        .select()
+        .from(journalSummaries)
+        .where(
+          and(
+            eq(journalSummaries.userId, userId),
+            eq(journalSummaries.period, data.period),
+            eq(journalSummaries.startDate, data.startDate),
+            eq(journalSummaries.endDate, data.endDate),
+          ),
+        )
+        .limit(1);
+
+      if (existingSummary.length > 0) {
+        return c.json(
+          {
+            success: false,
+            error: 'Journal summary for this period already exists. Use PUT to update it.',
+          },
+          409,
+        );
+      }
+
+      // Get journals in the date range
+      const journalsInPeriod = await db
+        .select()
+        .from(journals)
+        .where(
+          and(
+            eq(journals.userId, userId),
+            gte(journals.date, data.startDate),
+            lte(journals.date, data.endDate),
+            eq(journals.status, 'complete'), // Only include completed journals
+          ),
+        )
+        .orderBy(journals.date);
+
+      if (journalsInPeriod.length === 0) {
+        return c.json(
+          {
+            success: false,
+            error: 'No completed journal entries found for this period',
+          },
+          400,
+        );
+      }
+
+      // Generate summary using GPT
+      const { summary, tags } = await generatePeriodSummary(journalsInPeriod, data.period, userId);
+
+      // Create the summary record
+      const newSummary = await db
+        .insert(journalSummaries)
+        .values({
+          userId,
+          period: data.period,
+          startDate: data.startDate,
+          endDate: data.endDate,
+          summary,
+          tags,
+        })
+        .returning();
+
+      return c.json(
+        {
+          success: true,
+          data: serializeJournalSummary(newSummary[0]),
+        },
+        201,
+      );
+    } catch (error) {
+      return handleApiError(error, 'Failed to generate journal summary');
+    }
+  })
+
+  // Update an existing journal summary
+  .put('/:id', jwtAuth, zValidator('param', journalSummaryIdSchema), zValidator('json', updateJournalSummarySchema), async (c) => {
+    try {
+      const userId = getUserId(c);
+      const { id } = c.req.valid('param');
+      const data = c.req.valid('json') as UpdateJournalSummaryRequest;
+
+      // Check if summary exists and belongs to the user
+      const existingSummary = await db
+        .select()
+        .from(journalSummaries)
+        .where(and(eq(journalSummaries.id, id), eq(journalSummaries.userId, userId)))
+        .limit(1);
+
+      if (existingSummary.length === 0) {
+        return c.json(
+          {
+            success: false,
+            error: 'Journal summary not found',
+          },
+          404,
+        );
+      }
+
+      const updateData: any = {
+        updatedAt: new Date(),
+      };
+
+      // Only update provided fields
+      if (data.summary !== undefined) {
+        updateData.summary = data.summary;
+      }
+      if (data.tags !== undefined) {
+        updateData.tags = data.tags;
+      }
+
+      const updatedSummary = await db
+        .update(journalSummaries)
+        .set(updateData)
+        .where(and(eq(journalSummaries.id, id), eq(journalSummaries.userId, userId)))
+        .returning();
+
+      return c.json({
+        success: true,
+        data: serializeJournalSummary(updatedSummary[0]),
+      });
+    } catch (error) {
+      return handleApiError(error, 'Failed to update journal summary');
+    }
+  })
+
+  // Delete a journal summary
+  .delete('/:id', jwtAuth, zValidator('param', journalSummaryIdSchema), async (c) => {
+    try {
+      const userId = getUserId(c);
+      const { id } = c.req.valid('param');
+
+      // Get summary before deletion for response
+      const summaryToDelete = await db
+        .select()
+        .from(journalSummaries)
+        .where(and(eq(journalSummaries.id, id), eq(journalSummaries.userId, userId)))
+        .limit(1);
+
+      if (summaryToDelete.length === 0) {
+        return c.json(
+          {
+            success: false,
+            error: 'Journal summary not found',
+          },
+          404,
+        );
+      }
+
+      // Delete the summary
+      await db.delete(journalSummaries).where(and(eq(journalSummaries.id, id), eq(journalSummaries.userId, userId)));
+
+      return c.json({
+        success: true,
+        data: serializeJournalSummary(summaryToDelete[0]),
+      });
+    } catch (error) {
+      return handleApiError(error, 'Failed to delete journal summary');
+    }
+  });
+
+export default app;

--- a/backend/src/tests/journal-summaries.test.ts
+++ b/backend/src/tests/journal-summaries.test.ts
@@ -352,11 +352,7 @@ describe('Journal Summaries API Integration Tests', () => {
 
       // Verify summary was created in database
       const db = testDb();
-      const dbSummary = await db
-        .select()
-        .from(schema.journalSummaries)
-        .where(eq(schema.journalSummaries.id, responseData.data.id))
-        .limit(1);
+      const dbSummary = await db.select().from(schema.journalSummaries).where(eq(schema.journalSummaries.id, responseData.data.id)).limit(1);
 
       expect(dbSummary).toHaveLength(1);
       expect(dbSummary[0].summary).toBe(summaryData.summary);
@@ -576,11 +572,7 @@ describe('Journal Summaries API Integration Tests', () => {
       expect(responseData.data.tags).toEqual(['updated', 'new']);
 
       // Verify update in database
-      const dbSummary = await db
-        .select()
-        .from(schema.journalSummaries)
-        .where(eq(schema.journalSummaries.id, summary.id))
-        .limit(1);
+      const dbSummary = await db.select().from(schema.journalSummaries).where(eq(schema.journalSummaries.id, summary.id)).limit(1);
 
       expect(dbSummary[0].summary).toBe('Updated summary');
       expect(dbSummary[0].tags).toEqual(['updated', 'new']);
@@ -654,11 +646,7 @@ describe('Journal Summaries API Integration Tests', () => {
       expect(responseData.data.id).toBe(summary.id);
 
       // Verify deletion in database
-      const dbSummary = await db
-        .select()
-        .from(schema.journalSummaries)
-        .where(eq(schema.journalSummaries.id, summary.id))
-        .limit(1);
+      const dbSummary = await db.select().from(schema.journalSummaries).where(eq(schema.journalSummaries.id, summary.id)).limit(1);
 
       expect(dbSummary).toHaveLength(0);
     });

--- a/backend/src/tests/journal-summaries.test.ts
+++ b/backend/src/tests/journal-summaries.test.ts
@@ -1,0 +1,690 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import appExport from '../index';
+import { testDb, getUniqueEmail, schema } from './setup';
+import { eq, and } from 'drizzle-orm';
+
+// Create wrapper to maintain compatibility with test expectations
+const app = {
+  request: (url: string, init?: RequestInit) => {
+    const absoluteUrl = url.startsWith('http') ? url : `http://localhost${url}`;
+    return appExport.fetch(new Request(absoluteUrl, init));
+  },
+};
+
+describe('Journal Summaries API Integration Tests', () => {
+  let authToken: string;
+  let userId: string;
+  let testUser: { name: string; email: string; password: string };
+
+  beforeEach(async () => {
+    // Create a test user with unique email and get auth token for protected routes
+    testUser = {
+      name: 'Test User',
+      email: getUniqueEmail('journal-summaries'),
+      password: 'testpassword123',
+    };
+
+    const registerRes = await app.request('/api/users', {
+      method: 'POST',
+      body: JSON.stringify(testUser),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+
+    expect(registerRes.status).toBe(201);
+    const registerData = await registerRes.json();
+    authToken = registerData.token;
+    userId = registerData.user.id;
+  });
+
+  describe('GET /api/journal-summaries', () => {
+    it('should get empty list when no summaries exist', async () => {
+      const res = await app.request('/api/journal-summaries', {
+        headers: {
+          Authorization: `Bearer ${authToken}`,
+        },
+      });
+
+      expect(res.status).toBe(200);
+      const responseData = await res.json();
+      expect(responseData.success).toBe(true);
+      expect(responseData.data.summaries).toHaveLength(0);
+      expect(responseData.data.total).toBe(0);
+      expect(responseData.data.hasMore).toBe(false);
+    });
+
+    it('should get user summaries with pagination', async () => {
+      const db = testDb();
+
+      // Create test summaries
+      const summariesData = [
+        {
+          userId,
+          period: 'week' as const,
+          startDate: '2024-01-01',
+          endDate: '2024-01-07',
+          summary: 'Week 1 summary',
+          tags: ['tag1', 'tag2'],
+        },
+        {
+          userId,
+          period: 'week' as const,
+          startDate: '2024-01-08',
+          endDate: '2024-01-14',
+          summary: 'Week 2 summary',
+          tags: ['tag2', 'tag3'],
+        },
+        {
+          userId,
+          period: 'month' as const,
+          startDate: '2024-01-01',
+          endDate: '2024-01-31',
+          summary: 'January summary',
+          tags: ['monthly', 'review'],
+        },
+      ];
+
+      await db.insert(schema.journalSummaries).values(summariesData);
+
+      const res = await app.request('/api/journal-summaries?limit=2', {
+        headers: {
+          Authorization: `Bearer ${authToken}`,
+        },
+      });
+
+      expect(res.status).toBe(200);
+      const responseData = await res.json();
+      expect(responseData.success).toBe(true);
+      expect(responseData.data.summaries).toHaveLength(2);
+      expect(responseData.data.total).toBe(3);
+      expect(responseData.data.hasMore).toBe(true);
+    });
+
+    it('should filter by period type', async () => {
+      const db = testDb();
+
+      // Create test summaries
+      const summariesData = [
+        {
+          userId,
+          period: 'week' as const,
+          startDate: '2024-01-01',
+          endDate: '2024-01-07',
+          summary: 'Week summary',
+          tags: ['week'],
+        },
+        {
+          userId,
+          period: 'month' as const,
+          startDate: '2024-01-01',
+          endDate: '2024-01-31',
+          summary: 'Month summary',
+          tags: ['month'],
+        },
+      ];
+
+      await db.insert(schema.journalSummaries).values(summariesData);
+
+      const res = await app.request('/api/journal-summaries?period=week', {
+        headers: {
+          Authorization: `Bearer ${authToken}`,
+        },
+      });
+
+      expect(res.status).toBe(200);
+      const responseData = await res.json();
+      expect(responseData.success).toBe(true);
+      expect(responseData.data.summaries).toHaveLength(1);
+      expect(responseData.data.summaries[0].period).toBe('week');
+    });
+
+    it('should filter by year', async () => {
+      const db = testDb();
+
+      // Create test summaries for different years
+      const summariesData = [
+        {
+          userId,
+          period: 'week' as const,
+          startDate: '2024-01-01',
+          endDate: '2024-01-07',
+          summary: '2024 Week summary',
+          tags: ['2024'],
+        },
+        {
+          userId,
+          period: 'week' as const,
+          startDate: '2023-12-25',
+          endDate: '2023-12-31',
+          summary: '2023 Week summary',
+          tags: ['2023'],
+        },
+      ];
+
+      await db.insert(schema.journalSummaries).values(summariesData);
+
+      const res = await app.request('/api/journal-summaries?year=2024', {
+        headers: {
+          Authorization: `Bearer ${authToken}`,
+        },
+      });
+
+      expect(res.status).toBe(200);
+      const responseData = await res.json();
+      expect(responseData.success).toBe(true);
+      expect(responseData.data.summaries).toHaveLength(1);
+      expect(responseData.data.summaries[0].summary).toBe('2024 Week summary');
+    });
+
+    it('should only return summaries for authenticated user', async () => {
+      const db = testDb();
+
+      // Create another user
+      const anotherUser = await db
+        .insert(schema.users)
+        .values({
+          name: 'Another User',
+          email: getUniqueEmail('another-journal-summaries'),
+          password: 'password',
+        })
+        .returning();
+
+      // Create summaries for both users
+      await db.insert(schema.journalSummaries).values([
+        {
+          userId,
+          period: 'week' as const,
+          startDate: '2024-01-01',
+          endDate: '2024-01-07',
+          summary: 'My summary',
+          tags: ['mine'],
+        },
+        {
+          userId: anotherUser[0].id,
+          period: 'week' as const,
+          startDate: '2024-01-01',
+          endDate: '2024-01-07',
+          summary: 'Other summary',
+          tags: ['theirs'],
+        },
+      ]);
+
+      const res = await app.request('/api/journal-summaries', {
+        headers: {
+          Authorization: `Bearer ${authToken}`,
+        },
+      });
+
+      expect(res.status).toBe(200);
+      const responseData = await res.json();
+      expect(responseData.success).toBe(true);
+      expect(responseData.data.summaries).toHaveLength(1);
+      expect(responseData.data.summaries[0].summary).toBe('My summary');
+    });
+
+    it('should require authentication', async () => {
+      const res = await app.request('/api/journal-summaries');
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe('GET /api/journal-summaries/:id', () => {
+    it('should get specific summary by ID', async () => {
+      const db = testDb();
+
+      // Create test summary
+      const [summary] = await db
+        .insert(schema.journalSummaries)
+        .values({
+          userId,
+          period: 'week' as const,
+          startDate: '2024-01-01',
+          endDate: '2024-01-07',
+          summary: 'Specific summary',
+          tags: ['specific'],
+        })
+        .returning();
+
+      const res = await app.request(`/api/journal-summaries/${summary.id}`, {
+        headers: {
+          Authorization: `Bearer ${authToken}`,
+        },
+      });
+
+      expect(res.status).toBe(200);
+      const responseData = await res.json();
+      expect(responseData.success).toBe(true);
+      expect(responseData.data.id).toBe(summary.id);
+      expect(responseData.data.summary).toBe('Specific summary');
+      expect(responseData.data.period).toBe('week');
+      expect(responseData.data.tags).toEqual(['specific']);
+    });
+
+    it('should return 404 for non-existent summary', async () => {
+      const nonExistentId = '00000000-0000-0000-0000-000000000000';
+      const res = await app.request(`/api/journal-summaries/${nonExistentId}`, {
+        headers: {
+          Authorization: `Bearer ${authToken}`,
+        },
+      });
+
+      expect(res.status).toBe(404);
+      const responseData = await res.json();
+      expect(responseData.success).toBe(false);
+      expect(responseData.error).toBe('Journal summary not found');
+    });
+
+    it('should not allow access to other users summaries', async () => {
+      const db = testDb();
+
+      // Create another user
+      const anotherUser = await db
+        .insert(schema.users)
+        .values({
+          name: 'Another User',
+          email: getUniqueEmail('another-journal-summaries-get'),
+          password: 'password',
+        })
+        .returning();
+
+      // Create summary for other user
+      const [otherSummary] = await db
+        .insert(schema.journalSummaries)
+        .values({
+          userId: anotherUser[0].id,
+          period: 'week' as const,
+          startDate: '2024-01-01',
+          endDate: '2024-01-07',
+          summary: 'Other user summary',
+          tags: ['other'],
+        })
+        .returning();
+
+      const res = await app.request(`/api/journal-summaries/${otherSummary.id}`, {
+        headers: {
+          Authorization: `Bearer ${authToken}`,
+        },
+      });
+
+      expect(res.status).toBe(404);
+    });
+
+    it('should require authentication', async () => {
+      const res = await app.request('/api/journal-summaries/some-id');
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe('POST /api/journal-summaries', () => {
+    it('should create new summary', async () => {
+      const summaryData = {
+        period: 'week' as const,
+        startDate: '2024-01-01',
+        endDate: '2024-01-07',
+        summary: 'New week summary',
+        tags: ['new', 'week'],
+      };
+
+      const res = await app.request('/api/journal-summaries', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${authToken}`,
+        },
+        body: JSON.stringify(summaryData),
+      });
+
+      expect(res.status).toBe(201);
+      const responseData = await res.json();
+      expect(responseData.success).toBe(true);
+      expect(responseData.data).toMatchObject({
+        period: summaryData.period,
+        startDate: summaryData.startDate,
+        endDate: summaryData.endDate,
+        summary: summaryData.summary,
+        tags: summaryData.tags,
+        userId: userId,
+      });
+      expect(responseData.data).toHaveProperty('id');
+      expect(responseData.data).toHaveProperty('createdAt');
+      expect(responseData.data).toHaveProperty('updatedAt');
+
+      // Verify summary was created in database
+      const db = testDb();
+      const dbSummary = await db
+        .select()
+        .from(schema.journalSummaries)
+        .where(eq(schema.journalSummaries.id, responseData.data.id))
+        .limit(1);
+
+      expect(dbSummary).toHaveLength(1);
+      expect(dbSummary[0].summary).toBe(summaryData.summary);
+      expect(dbSummary[0].userId).toBe(userId);
+    });
+
+    it('should prevent duplicate summaries for same period', async () => {
+      const summaryData = {
+        period: 'week' as const,
+        startDate: '2024-01-01',
+        endDate: '2024-01-07',
+        summary: 'First summary',
+        tags: ['first'],
+      };
+
+      // Create first summary
+      const res1 = await app.request('/api/journal-summaries', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${authToken}`,
+        },
+        body: JSON.stringify(summaryData),
+      });
+
+      expect(res1.status).toBe(201);
+
+      // Try to create duplicate
+      const res2 = await app.request('/api/journal-summaries', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${authToken}`,
+        },
+        body: JSON.stringify({
+          ...summaryData,
+          summary: 'Second summary',
+        }),
+      });
+
+      expect(res2.status).toBe(409);
+      const responseData = await res2.json();
+      expect(responseData.success).toBe(false);
+      expect(responseData.error).toBe('Journal summary for this period already exists');
+    });
+
+    it('should validate required fields', async () => {
+      const invalidData = {
+        period: 'week',
+        startDate: '2024-01-01',
+        // Missing endDate and summary
+      };
+
+      const res = await app.request('/api/journal-summaries', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${authToken}`,
+        },
+        body: JSON.stringify(invalidData),
+      });
+
+      expect(res.status).toBe(400);
+    });
+
+    it('should validate date format', async () => {
+      const invalidData = {
+        period: 'week',
+        startDate: 'invalid-date',
+        endDate: '2024-01-07',
+        summary: 'Test summary',
+      };
+
+      const res = await app.request('/api/journal-summaries', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${authToken}`,
+        },
+        body: JSON.stringify(invalidData),
+      });
+
+      expect(res.status).toBe(400);
+    });
+
+    it('should require authentication', async () => {
+      const summaryData = {
+        period: 'week',
+        startDate: '2024-01-01',
+        endDate: '2024-01-07',
+        summary: 'Test summary',
+      };
+
+      const res = await app.request('/api/journal-summaries', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(summaryData),
+      });
+
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe('POST /api/journal-summaries/generate', () => {
+    it('should fail when no completed journals exist', async () => {
+      const generateData = {
+        period: 'week' as const,
+        startDate: '2024-01-01',
+        endDate: '2024-01-07',
+      };
+
+      const res = await app.request('/api/journal-summaries/generate', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${authToken}`,
+        },
+        body: JSON.stringify(generateData),
+      });
+
+      expect(res.status).toBe(400);
+      const responseData = await res.json();
+      expect(responseData.success).toBe(false);
+      expect(responseData.error).toBe('No completed journal entries found for this period');
+    });
+
+    it('should prevent duplicate generation for same period', async () => {
+      const db = testDb();
+
+      // Create a summary first
+      await db.insert(schema.journalSummaries).values({
+        userId,
+        period: 'week' as const,
+        startDate: '2024-01-01',
+        endDate: '2024-01-07',
+        summary: 'Existing summary',
+        tags: ['existing'],
+      });
+
+      const generateData = {
+        period: 'week' as const,
+        startDate: '2024-01-01',
+        endDate: '2024-01-07',
+      };
+
+      const res = await app.request('/api/journal-summaries/generate', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${authToken}`,
+        },
+        body: JSON.stringify(generateData),
+      });
+
+      expect(res.status).toBe(409);
+      const responseData = await res.json();
+      expect(responseData.success).toBe(false);
+      expect(responseData.error).toBe('Journal summary for this period already exists. Use PUT to update it.');
+    });
+
+    it('should require authentication', async () => {
+      const generateData = {
+        period: 'week',
+        startDate: '2024-01-01',
+        endDate: '2024-01-07',
+      };
+
+      const res = await app.request('/api/journal-summaries/generate', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(generateData),
+      });
+
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe('PUT /api/journal-summaries/:id', () => {
+    it('should update existing summary', async () => {
+      const db = testDb();
+
+      // Create test summary
+      const [summary] = await db
+        .insert(schema.journalSummaries)
+        .values({
+          userId,
+          period: 'week' as const,
+          startDate: '2024-01-01',
+          endDate: '2024-01-07',
+          summary: 'Original summary',
+          tags: ['original'],
+        })
+        .returning();
+
+      const updateData = {
+        summary: 'Updated summary',
+        tags: ['updated', 'new'],
+      };
+
+      const res = await app.request(`/api/journal-summaries/${summary.id}`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${authToken}`,
+        },
+        body: JSON.stringify(updateData),
+      });
+
+      expect(res.status).toBe(200);
+      const responseData = await res.json();
+      expect(responseData.success).toBe(true);
+      expect(responseData.data.summary).toBe('Updated summary');
+      expect(responseData.data.tags).toEqual(['updated', 'new']);
+
+      // Verify update in database
+      const dbSummary = await db
+        .select()
+        .from(schema.journalSummaries)
+        .where(eq(schema.journalSummaries.id, summary.id))
+        .limit(1);
+
+      expect(dbSummary[0].summary).toBe('Updated summary');
+      expect(dbSummary[0].tags).toEqual(['updated', 'new']);
+    });
+
+    it('should return 404 for non-existent summary', async () => {
+      const nonExistentId = '00000000-0000-0000-0000-000000000000';
+      const updateData = {
+        summary: 'Updated summary',
+      };
+
+      const res = await app.request(`/api/journal-summaries/${nonExistentId}`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${authToken}`,
+        },
+        body: JSON.stringify(updateData),
+      });
+
+      expect(res.status).toBe(404);
+      const responseData = await res.json();
+      expect(responseData.success).toBe(false);
+      expect(responseData.error).toBe('Journal summary not found');
+    });
+
+    it('should require authentication', async () => {
+      const updateData = {
+        summary: 'Updated summary',
+      };
+
+      const res = await app.request('/api/journal-summaries/some-id', {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(updateData),
+      });
+
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe('DELETE /api/journal-summaries/:id', () => {
+    it('should delete existing summary', async () => {
+      const db = testDb();
+
+      // Create test summary
+      const [summary] = await db
+        .insert(schema.journalSummaries)
+        .values({
+          userId,
+          period: 'week' as const,
+          startDate: '2024-01-01',
+          endDate: '2024-01-07',
+          summary: 'Summary to delete',
+          tags: ['delete'],
+        })
+        .returning();
+
+      const res = await app.request(`/api/journal-summaries/${summary.id}`, {
+        method: 'DELETE',
+        headers: {
+          Authorization: `Bearer ${authToken}`,
+        },
+      });
+
+      expect(res.status).toBe(200);
+      const responseData = await res.json();
+      expect(responseData.success).toBe(true);
+      expect(responseData.data.id).toBe(summary.id);
+
+      // Verify deletion in database
+      const dbSummary = await db
+        .select()
+        .from(schema.journalSummaries)
+        .where(eq(schema.journalSummaries.id, summary.id))
+        .limit(1);
+
+      expect(dbSummary).toHaveLength(0);
+    });
+
+    it('should return 404 for non-existent summary', async () => {
+      const nonExistentId = '00000000-0000-0000-0000-000000000000';
+
+      const res = await app.request(`/api/journal-summaries/${nonExistentId}`, {
+        method: 'DELETE',
+        headers: {
+          Authorization: `Bearer ${authToken}`,
+        },
+      });
+
+      expect(res.status).toBe(404);
+      const responseData = await res.json();
+      expect(responseData.success).toBe(false);
+      expect(responseData.error).toBe('Journal summary not found');
+    });
+
+    it('should require authentication', async () => {
+      const res = await app.request('/api/journal-summaries/some-id', {
+        method: 'DELETE',
+      });
+
+      expect(res.status).toBe(401);
+    });
+  });
+});

--- a/backend/src/types/journal-summaries.ts
+++ b/backend/src/types/journal-summaries.ts
@@ -1,0 +1,49 @@
+import type { journalSummaries } from '../db/schema/journal-summaries';
+
+export type JournalSummary = typeof journalSummaries.$inferSelect;
+export type NewJournalSummary = typeof journalSummaries.$inferInsert;
+
+// Request/Response types for API
+export interface CreateJournalSummaryRequest {
+  period: 'week' | 'month';
+  startDate: string; // YYYY-MM-DD format
+  endDate: string; // YYYY-MM-DD format
+  summary: string;
+  tags?: string[];
+}
+
+export interface UpdateJournalSummaryRequest {
+  summary?: string;
+  tags?: string[];
+}
+
+export interface ListJournalSummariesRequest {
+  period?: 'week' | 'month';
+  limit?: number;
+  offset?: number;
+  year?: number;
+}
+
+export interface GenerateJournalSummaryRequest {
+  period: 'week' | 'month';
+  startDate: string; // YYYY-MM-DD format
+  endDate: string; // YYYY-MM-DD format
+}
+
+export interface JournalSummaryResponse {
+  id: string;
+  userId: string;
+  period: 'week' | 'month';
+  startDate: string;
+  endDate: string;
+  summary: string;
+  tags: string[] | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ListJournalSummariesResponse {
+  summaries: JournalSummaryResponse[];
+  total: number;
+  hasMore: boolean;
+}

--- a/backend/src/utils/gpt/periodSummary.ts
+++ b/backend/src/utils/gpt/periodSummary.ts
@@ -1,0 +1,189 @@
+import { ChatCompletionMessageParam } from 'openai/resources';
+import { callGptApi } from './client';
+import { getUserContext, formatUserContextForPrompt, type ComprehensiveUserContext } from '../userContextService';
+import type { journals } from '../../db/schema/journals';
+
+/**
+ * Interface for period summary generation result
+ */
+export interface PeriodSummaryResult {
+  summary: string;
+  tags: string[];
+}
+
+/**
+ * System prompt for generating period summaries
+ */
+function createPeriodSummarySystemPrompt(userContext: ComprehensiveUserContext, period: 'week' | 'month'): string {
+  return `You are a thoughtful journal curator helping ${userContext.name} understand patterns and themes across their ${period}.
+
+Your task is to create a cohesive narrative summary of their journal entries from this ${period}. This summary will be used to provide context for future journal conversations.
+
+## User Context
+${formatUserContextForPrompt(userContext)}
+
+## Instructions
+
+1. **Create a flowing narrative summary** that captures:
+   - Major themes and patterns
+   - Emotional arcs and moods
+   - Significant events and experiences
+   - Growth areas and insights
+   - Challenges and wins
+
+2. **Extract meaningful tags** (3-8 tags) that represent:
+   - Key topics that came up frequently
+   - Emotional themes
+   - Activities or life areas that were prominent
+   - Relationship dynamics
+   - Personal growth areas
+
+3. **Style guidelines:**
+   - Write in third person about the user
+   - Maintain a warm, observational tone
+   - Connect themes across different entries
+   - Be specific enough to trigger memories but concise
+   - Length: 2-4 paragraphs for weeks, 3-6 paragraphs for months
+
+4. **Format your response as JSON:**
+\`\`\`json
+{
+  "summary": "Your narrative summary here...",
+  "tags": ["tag1", "tag2", "tag3", "tag4"]
+}
+\`\`\`
+
+Focus on patterns and themes rather than day-by-day recaps. This summary should help provide rich context for future journal conversations.`;
+}
+
+/**
+ * Generate a summary for a week or month based on journal entries
+ */
+export async function generatePeriodSummary(
+  journalEntries: (typeof journals.$inferSelect)[],
+  period: 'week' | 'month',
+  userId: string,
+): Promise<PeriodSummaryResult> {
+  // Get user context for personalized summary generation
+  const userContext = await getUserContext(userId, {
+    includeCharacter: true,
+    includeActiveGoals: true,
+    includeFamilyMembers: true,
+    includeCharacterStats: true,
+    includeExistingTags: false, // We'll generate fresh tags
+  });
+
+  // Create the system prompt
+  const systemPrompt = createPeriodSummarySystemPrompt(userContext, period);
+
+  // Prepare the messages for the API
+  const messages: ChatCompletionMessageParam[] = [{ role: 'system', content: systemPrompt }];
+
+  // Add journal entries as context
+  let journalContent = `Here are the journal entries from this ${period}:\n\n`;
+
+  journalEntries.forEach((journal, index) => {
+    journalContent += `**${journal.date}**\n`;
+    
+    if (journal.title) {
+      journalContent += `Title: ${journal.title}\n`;
+    }
+    
+    if (journal.synopsis) {
+      journalContent += `Synopsis: ${journal.synopsis}\n`;
+    }
+    
+    if (journal.summary) {
+      journalContent += `Summary: ${journal.summary}\n`;
+    } else if (journal.initialMessage) {
+      // If no summary, use initial message
+      journalContent += `Content: ${journal.initialMessage}\n`;
+    }
+    
+    if (journal.dayRating || journal.inferredDayRating) {
+      const rating = journal.dayRating || journal.inferredDayRating;
+      journalContent += `Day Rating: ${rating}/5\n`;
+    }
+    
+    journalContent += '\n---\n\n';
+  });
+
+  messages.push({
+    role: 'user',
+    content: journalContent,
+  });
+
+  messages.push({
+    role: 'user',
+    content: `Please generate a ${period}ly summary based on these journal entries. Return only the JSON response as specified.`,
+  });
+
+  const response = await callGptApi({
+    messages,
+    temperature: 0.7, // Balanced creativity for narrative flow
+  });
+
+  try {
+    let responseContent = response.content.trim();
+
+    // Handle code block formatting
+    if (responseContent.startsWith('```json')) {
+      responseContent = responseContent
+        .replace(/```json/, '')
+        .replace(/```/, '')
+        .trim();
+    }
+
+    const result = JSON.parse(responseContent);
+
+    // Validate the response structure
+    if (!result.summary || !Array.isArray(result.tags)) {
+      throw new Error('Invalid response format from GPT');
+    }
+
+    return {
+      summary: result.summary,
+      tags: result.tags,
+    };
+  } catch (error) {
+    throw new Error(`Failed to parse GPT period summary response: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+/**
+ * Helper function to calculate week boundaries (Saturday to Friday)
+ */
+export function getWeekBoundaries(date: Date): { startDate: string; endDate: string } {
+  const inputDate = new Date(date);
+  
+  // Find the Saturday that starts this week
+  const dayOfWeek = inputDate.getDay(); // 0 = Sunday, 6 = Saturday
+  const daysToSubtract = dayOfWeek === 6 ? 0 : dayOfWeek + 1; // Saturday = 0 days back
+  
+  const saturday = new Date(inputDate);
+  saturday.setDate(inputDate.getDate() - daysToSubtract);
+  
+  // Friday is 6 days after Saturday
+  const friday = new Date(saturday);
+  friday.setDate(saturday.getDate() + 6);
+  
+  return {
+    startDate: saturday.toISOString().split('T')[0], // YYYY-MM-DD
+    endDate: friday.toISOString().split('T')[0], // YYYY-MM-DD
+  };
+}
+
+/**
+ * Helper function to calculate month boundaries
+ */
+export function getMonthBoundaries(date: Date): { startDate: string; endDate: string } {
+  const inputDate = new Date(date);
+  
+  const firstDay = new Date(inputDate.getFullYear(), inputDate.getMonth(), 1);
+  const lastDay = new Date(inputDate.getFullYear(), inputDate.getMonth() + 1, 0);
+  
+  return {
+    startDate: firstDay.toISOString().split('T')[0], // YYYY-MM-DD
+    endDate: lastDay.toISOString().split('T')[0], // YYYY-MM-DD
+  };
+}

--- a/backend/src/utils/gpt/periodSummary.ts
+++ b/backend/src/utils/gpt/periodSummary.ts
@@ -84,12 +84,12 @@ export async function generatePeriodSummary(
 
   journalEntries.forEach((journal, index) => {
     journalContent += `**${journal.date}**\n`;
-    
+
     // Since summary is AI generated, only use initialMessage for user's original voice
     if (journal.initialMessage) {
       journalContent += `Content: ${journal.initialMessage}\n`;
     }
-    
+
     journalContent += '\n---\n\n';
   });
 
@@ -140,18 +140,18 @@ export async function generatePeriodSummary(
  */
 export function getWeekBoundaries(date: Date): { startDate: string; endDate: string } {
   const inputDate = new Date(date);
-  
+
   // Find the Saturday that starts this week
   const dayOfWeek = inputDate.getDay(); // 0 = Sunday, 6 = Saturday
   const daysToSubtract = dayOfWeek === 6 ? 0 : dayOfWeek + 1; // Saturday = 0 days back
-  
+
   const saturday = new Date(inputDate);
   saturday.setDate(inputDate.getDate() - daysToSubtract);
-  
+
   // Friday is 6 days after Saturday
   const friday = new Date(saturday);
   friday.setDate(saturday.getDate() + 6);
-  
+
   return {
     startDate: saturday.toISOString().split('T')[0], // YYYY-MM-DD
     endDate: friday.toISOString().split('T')[0], // YYYY-MM-DD
@@ -163,10 +163,10 @@ export function getWeekBoundaries(date: Date): { startDate: string; endDate: str
  */
 export function getMonthBoundaries(date: Date): { startDate: string; endDate: string } {
   const inputDate = new Date(date);
-  
+
   const firstDay = new Date(inputDate.getFullYear(), inputDate.getMonth(), 1);
   const lastDay = new Date(inputDate.getFullYear(), inputDate.getMonth() + 1, 0);
-  
+
   return {
     startDate: firstDay.toISOString().split('T')[0], // YYYY-MM-DD
     endDate: lastDay.toISOString().split('T')[0], // YYYY-MM-DD

--- a/backend/src/utils/gpt/periodSummary.ts
+++ b/backend/src/utils/gpt/periodSummary.ts
@@ -39,7 +39,7 @@ ${formatUserContextForPrompt(userContext)}
    - Personal growth areas
 
 3. **Style guidelines:**
-   - Write in third person about the user
+   - Write in first person from the user's perspective
    - Maintain a warm, observational tone
    - Connect themes across different entries
    - Be specific enough to trigger memories but concise
@@ -53,7 +53,7 @@ ${formatUserContextForPrompt(userContext)}
 }
 \`\`\`
 
-Focus on patterns and themes rather than day-by-day recaps. This summary should help provide rich context for future journal conversations.`;
+Focus on patterns and themes rather than day-by-day recaps. This summary should help provide rich context for future journal conversations. Markdown is supported.`;
 }
 
 /**
@@ -85,24 +85,9 @@ export async function generatePeriodSummary(
   journalEntries.forEach((journal, index) => {
     journalContent += `**${journal.date}**\n`;
     
-    if (journal.title) {
-      journalContent += `Title: ${journal.title}\n`;
-    }
-    
-    if (journal.synopsis) {
-      journalContent += `Synopsis: ${journal.synopsis}\n`;
-    }
-    
-    if (journal.summary) {
-      journalContent += `Summary: ${journal.summary}\n`;
-    } else if (journal.initialMessage) {
-      // If no summary, use initial message
+    // Since summary is AI generated, only use initialMessage for user's original voice
+    if (journal.initialMessage) {
       journalContent += `Content: ${journal.initialMessage}\n`;
-    }
-    
-    if (journal.dayRating || journal.inferredDayRating) {
-      const rating = journal.dayRating || journal.inferredDayRating;
-      journalContent += `Day Rating: ${rating}/5\n`;
     }
     
     journalContent += '\n---\n\n';

--- a/backend/src/validation/journal-summaries.ts
+++ b/backend/src/validation/journal-summaries.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+
+export const createJournalSummarySchema = z.object({
+  period: z.enum(['week', 'month']),
+  startDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Start date must be in YYYY-MM-DD format'),
+  endDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'End date must be in YYYY-MM-DD format'),
+  summary: z.string().min(1, 'Summary is required'),
+  tags: z.array(z.string()).optional(),
+});
+
+export const updateJournalSummarySchema = z.object({
+  summary: z.string().min(1, 'Summary is required').optional(),
+  tags: z.array(z.string()).optional(),
+});
+
+export const listJournalSummariesSchema = z.object({
+  period: z.enum(['week', 'month']).optional(),
+  limit: z.coerce.number().min(1).max(50).optional().default(20),
+  offset: z.coerce.number().min(0).optional().default(0),
+  year: z.coerce.number().min(2020).max(2100).optional(),
+});
+
+export const journalSummaryIdSchema = z.object({
+  id: z.string().uuid('Invalid summary ID'),
+});
+
+export const generateJournalSummarySchema = z.object({
+  period: z.enum(['week', 'month']),
+  startDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Start date must be in YYYY-MM-DD format'),
+  endDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'End date must be in YYYY-MM-DD format'),
+});

--- a/copilot/features/summaries.md
+++ b/copilot/features/summaries.md
@@ -24,37 +24,37 @@ This table will store summaries of journal content aggregated over time.
 }
 ````
 
-* One summary per period.
-* Summaries are generated via GPT and stored in full.
-* Could be scheduled as a cron job or triggered manually.
+- One summary per period.
+- Summaries are generated via GPT and stored in full.
+- Could be scheduled as a cron job or triggered manually.
 
 #### 2. Logic
 
-* Aggregate all journal entries for the given period.
-* Extract top themes, moods, wins, and challenges.
-* Generate a human-readable summary via GPT.
-* Store the result in `journal_summaries`.
+- Aggregate all journal entries for the given period.
+- Extract top themes, moods, wins, and challenges.
+- Generate a human-readable summary via GPT.
+- Store the result in `journal_summaries`.
 
 #### 3. GPT Usage
 
-* When a user starts a new journal entry or a GPT conversation about a past entry:
-
-  * Load the relevant **weekly** and **monthly** summaries.
-  * Prepend them to the GPT context to provide emotional and thematic background.
+- When a user starts a new journal entry or a GPT conversation about a past entry:
+  - Load the relevant **weekly** and **monthly** summaries.
+  - Prepend them to the GPT context to provide emotional and thematic background.
 
 ---
 
 ### 🧠 Why It Matters
 
-* Provides GPT with long-term memory of how a user’s month or week has gone.
-* Useful for trend spotting, emotional awareness, or connecting journal dots.
-* Builds toward future features like XP trend analysis, check-ins, and guided self-reflection.
+- Provides GPT with long-term memory of how a user’s month or week has gone.
+- Useful for trend spotting, emotional awareness, or connecting journal dots.
+- Builds toward future features like XP trend analysis, check-ins, and guided self-reflection.
 
 ---
 
 ### 📌 Notes
 
-* Ensure summaries are recomputable if older journals are updated.
-* Can be extended later to include rating trends, stat deltas, etc.
-* User annotations or editable summaries
+- Ensure summaries are recomputable if older journals are updated.
+- Can be extended later to include rating trends, stat deltas, etc.
+- User annotations or editable summaries
+
 ---

--- a/copilot/features/summaries.md
+++ b/copilot/features/summaries.md
@@ -1,0 +1,60 @@
+## ✅ Weekly & Monthly Summaries for Journal Context
+
+````
+### 🧠 Feature: Weekly & Monthly Summaries
+
+Add system-generated summaries of weeks and months to provide GPT with richer context during journal entry conversations.
+
+---
+
+### ✅ What to Build
+
+#### 1. New Table: `journal_summaries`
+This table will store summaries of journal content aggregated over time.
+
+```ts
+{
+  id: uuid,
+  period: 'week' | 'month',
+  startDate: date,  // Saturday for weeks, 1st of month for months
+  endDate: date,    // Friday for weeks, last day of month
+  summary: text,    // Generated long-form summary (used for GPT context)
+  tags: string[],   // Optional: top tags extracted from entries
+  createdAt: timestamp
+}
+````
+
+* One summary per period.
+* Summaries are generated via GPT and stored in full.
+* Could be scheduled as a cron job or triggered manually.
+
+#### 2. Logic
+
+* Aggregate all journal entries for the given period.
+* Extract top themes, moods, wins, and challenges.
+* Generate a human-readable summary via GPT.
+* Store the result in `journal_summaries`.
+
+#### 3. GPT Usage
+
+* When a user starts a new journal entry or a GPT conversation about a past entry:
+
+  * Load the relevant **weekly** and **monthly** summaries.
+  * Prepend them to the GPT context to provide emotional and thematic background.
+
+---
+
+### 🧠 Why It Matters
+
+* Provides GPT with long-term memory of how a user’s month or week has gone.
+* Useful for trend spotting, emotional awareness, or connecting journal dots.
+* Builds toward future features like XP trend analysis, check-ins, and guided self-reflection.
+
+---
+
+### 📌 Notes
+
+* Ensure summaries are recomputable if older journals are updated.
+* Can be extended later to include rating trends, stat deltas, etc.
+* User annotations or editable summaries
+---

--- a/frontend/src/lib/api/journal-summaries.ts
+++ b/frontend/src/lib/api/journal-summaries.ts
@@ -1,0 +1,140 @@
+import { apiFetch } from '../api';
+import type {
+  JournalSummaryResponse,
+  ListJournalSummariesResponse,
+  CreateJournalSummaryRequest,
+  UpdateJournalSummaryRequest,
+  ListJournalSummariesRequest,
+  GenerateJournalSummaryRequest,
+} from '../types/journal-summaries';
+
+// Type-safe journal summaries API using fetch wrapper
+export const journalSummariesApi = {
+  // Get user's journal summaries with filtering and pagination
+  async getJournalSummaries(params: Partial<ListJournalSummariesRequest> = {}): Promise<ListJournalSummariesResponse> {
+    const searchParams = new URLSearchParams();
+
+    if (params.limit !== undefined) searchParams.set('limit', params.limit.toString());
+    if (params.offset !== undefined) searchParams.set('offset', params.offset.toString());
+    if (params.period) searchParams.set('period', params.period);
+    if (params.year !== undefined) searchParams.set('year', params.year.toString());
+
+    const queryString = searchParams.toString();
+    const url = queryString ? `/api/journal-summaries?${queryString}` : '/api/journal-summaries';
+
+    const response = await apiFetch(url);
+    return response.data;
+  },
+
+  // Get specific journal summary by ID
+  async getJournalSummary(summaryId: string): Promise<JournalSummaryResponse> {
+    const response = await apiFetch(`/api/journal-summaries/${summaryId}`);
+    return response.data;
+  },
+
+  // Create a new journal summary (manual creation)
+  async createJournalSummary(data: CreateJournalSummaryRequest): Promise<JournalSummaryResponse> {
+    const response = await apiFetch('/api/journal-summaries', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+    return response.data;
+  },
+
+  // Generate a journal summary using GPT
+  async generateJournalSummary(data: GenerateJournalSummaryRequest): Promise<JournalSummaryResponse> {
+    const response = await apiFetch('/api/journal-summaries/generate', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+    return response.data;
+  },
+
+  // Update an existing journal summary
+  async updateJournalSummary(summaryId: string, data: UpdateJournalSummaryRequest): Promise<JournalSummaryResponse> {
+    const response = await apiFetch(`/api/journal-summaries/${summaryId}`, {
+      method: 'PUT',
+      body: JSON.stringify(data),
+    });
+    return response.data;
+  },
+
+  // Delete a journal summary
+  async deleteJournalSummary(summaryId: string): Promise<JournalSummaryResponse> {
+    const response = await apiFetch(`/api/journal-summaries/${summaryId}`, {
+      method: 'DELETE',
+    });
+    return response.data;
+  },
+};
+
+// Helper functions for date calculations
+export const journalSummariesUtils = {
+  /**
+   * Calculate week boundaries (Saturday to Friday)
+   */
+  getWeekBoundaries(date: Date): { startDate: string; endDate: string } {
+    const inputDate = new Date(date);
+    
+    // Find the Saturday that starts this week
+    const dayOfWeek = inputDate.getDay(); // 0 = Sunday, 6 = Saturday
+    const daysToSubtract = dayOfWeek === 6 ? 0 : dayOfWeek + 1; // Saturday = 0 days back
+    
+    const saturday = new Date(inputDate);
+    saturday.setDate(inputDate.getDate() - daysToSubtract);
+    
+    // Friday is 6 days after Saturday
+    const friday = new Date(saturday);
+    friday.setDate(saturday.getDate() + 6);
+    
+    return {
+      startDate: saturday.toISOString().split('T')[0], // YYYY-MM-DD
+      endDate: friday.toISOString().split('T')[0], // YYYY-MM-DD
+    };
+  },
+
+  /**
+   * Calculate month boundaries
+   */
+  getMonthBoundaries(date: Date): { startDate: string; endDate: string } {
+    const inputDate = new Date(date);
+    
+    const firstDay = new Date(inputDate.getFullYear(), inputDate.getMonth(), 1);
+    const lastDay = new Date(inputDate.getFullYear(), inputDate.getMonth() + 1, 0);
+    
+    return {
+      startDate: firstDay.toISOString().split('T')[0], // YYYY-MM-DD
+      endDate: lastDay.toISOString().split('T')[0], // YYYY-MM-DD
+    };
+  },
+
+  /**
+   * Format period for display
+   */
+  formatPeriod(period: 'week' | 'month', startDate: string, endDate: string): string {
+    const start = new Date(startDate);
+    const end = new Date(endDate);
+    
+    if (period === 'month') {
+      return start.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
+    } else {
+      const startFormatted = start.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+      const endFormatted = end.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+      return `${startFormatted} - ${endFormatted}`;
+    }
+  },
+
+  /**
+   * Get current week boundaries
+   */
+  getCurrentWeekBoundaries(): { startDate: string; endDate: string } {
+    return this.getWeekBoundaries(new Date());
+  },
+
+  /**
+   * Get current month boundaries
+   */
+  getCurrentMonthBoundaries(): { startDate: string; endDate: string } {
+    return this.getMonthBoundaries(new Date());
+  },
+};

--- a/frontend/src/lib/api/journal-summaries.ts
+++ b/frontend/src/lib/api/journal-summaries.ts
@@ -75,18 +75,18 @@ export const journalSummariesUtils = {
    */
   getWeekBoundaries(date: Date): { startDate: string; endDate: string } {
     const inputDate = new Date(date);
-    
+
     // Find the Saturday that starts this week
     const dayOfWeek = inputDate.getDay(); // 0 = Sunday, 6 = Saturday
     const daysToSubtract = dayOfWeek === 6 ? 0 : dayOfWeek + 1; // Saturday = 0 days back
-    
+
     const saturday = new Date(inputDate);
     saturday.setDate(inputDate.getDate() - daysToSubtract);
-    
+
     // Friday is 6 days after Saturday
     const friday = new Date(saturday);
     friday.setDate(saturday.getDate() + 6);
-    
+
     return {
       startDate: saturday.toISOString().split('T')[0], // YYYY-MM-DD
       endDate: friday.toISOString().split('T')[0], // YYYY-MM-DD
@@ -98,10 +98,10 @@ export const journalSummariesUtils = {
    */
   getMonthBoundaries(date: Date): { startDate: string; endDate: string } {
     const inputDate = new Date(date);
-    
+
     const firstDay = new Date(inputDate.getFullYear(), inputDate.getMonth(), 1);
     const lastDay = new Date(inputDate.getFullYear(), inputDate.getMonth() + 1, 0);
-    
+
     return {
       startDate: firstDay.toISOString().split('T')[0], // YYYY-MM-DD
       endDate: lastDay.toISOString().split('T')[0], // YYYY-MM-DD
@@ -114,7 +114,7 @@ export const journalSummariesUtils = {
   formatPeriod(period: 'week' | 'month', startDate: string, endDate: string): string {
     const start = new Date(startDate);
     const end = new Date(endDate);
-    
+
     if (period === 'month') {
       return start.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
     } else {

--- a/frontend/src/lib/components/journal/JournalDashboard.svelte
+++ b/frontend/src/lib/components/journal/JournalDashboard.svelte
@@ -4,7 +4,7 @@
   import { JournalService } from '$lib/api/journal';
   import type { JournalListItem, ListJournalsResponse } from '$lib/types/journal';
   import JournalHeatmap from '$lib/components/journal/JournalHeatmap.svelte';
-  import { BookOpenIcon, CalendarDaysIcon, ListIcon, PlusIcon } from 'lucide-svelte';
+  import { BookOpenIcon, CalendarDaysIcon, ListIcon, PlusIcon, SparklesIcon } from 'lucide-svelte';
   import { getTodayDateString, formatDate } from '$lib/utils/date';
 
   let loading = true;
@@ -58,6 +58,10 @@
     goto('/journals');
   }
 
+  function goToSummaries() {
+    goto('/journal-summaries');
+  }
+
   $: journals = journalData?.journals || [];
   $: completedJournals = journals.filter((j) => j.status === 'complete');
 
@@ -87,6 +91,10 @@
     </div>
 
     <div class="flex gap-2">
+      <button class="btn btn-ghost btn-sm" on:click={goToSummaries}>
+        <SparklesIcon size={16} />
+        <span class="hidden sm:inline">Summaries</span>
+      </button>
       <button class="btn btn-ghost btn-sm" on:click={goToJournalsList}>
         <ListIcon size={16} />
         <span class="hidden sm:inline">All Entries</span>

--- a/frontend/src/lib/types/journal-summaries.ts
+++ b/frontend/src/lib/types/journal-summaries.ts
@@ -1,0 +1,45 @@
+// Import types from backend (single source of truth)
+export type {
+  JournalSummary,
+  NewJournalSummary,
+  CreateJournalSummaryRequest,
+  UpdateJournalSummaryRequest,
+  ListJournalSummariesRequest,
+  GenerateJournalSummaryRequest,
+  JournalSummaryResponse,
+  ListJournalSummariesResponse,
+} from '../../../../backend/src/types/journal-summaries';
+
+// Additional frontend-specific types for UI state
+export interface JournalSummaryFormData {
+  period: 'week' | 'month';
+  startDate: string;
+  endDate: string;
+  summary: string;
+  tags?: string[];
+}
+
+export interface UpdateJournalSummaryFormData {
+  summary?: string;
+  tags?: string[];
+}
+
+export interface GenerateJournalSummaryFormData {
+  period: 'week' | 'month';
+  startDate: string;
+  endDate: string;
+}
+
+// UI filter types
+export interface JournalSummaryFilters {
+  period?: 'week' | 'month';
+  year?: number;
+  limit?: number;
+  offset?: number;
+}
+
+// Helper types for date calculations
+export interface DateRange {
+  startDate: string;
+  endDate: string;
+}

--- a/frontend/src/routes/journal-summaries/+page.svelte
+++ b/frontend/src/routes/journal-summaries/+page.svelte
@@ -1,0 +1,339 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { goto } from '$app/navigation';
+  import { journalSummariesApi, journalSummariesUtils } from '$lib/api/journal-summaries';
+  import type { JournalSummaryResponse, ListJournalSummariesResponse } from '$lib/types/journal-summaries';
+  import { 
+    BookOpenIcon, 
+    CalendarIcon, 
+    PlusIcon, 
+    FilterIcon, 
+    RefreshCwIcon,
+    ClockIcon,
+    TagIcon,
+    ChevronLeftIcon,
+    ChevronRightIcon
+  } from 'lucide-svelte';
+  import { formatDateTime } from '$lib/utils/date';
+
+  // State
+  let summaries: JournalSummaryResponse[] = [];
+  let totalSummaries = 0;
+  let hasMore = false;
+  let loading = true;
+  let error: string | null = null;
+  
+  // Filters
+  let periodFilter: 'all' | 'week' | 'month' = 'all';
+  let yearFilter: number | null = null;
+  
+  // Pagination
+  const ITEMS_PER_PAGE = 12;
+  let currentPage = 0;
+
+  onMount(async () => {
+    await loadSummaries();
+  });
+
+  async function loadSummaries(reset = true) {
+    try {
+      loading = true;
+      error = null;
+
+      const params: any = {
+        limit: ITEMS_PER_PAGE,
+        offset: reset ? 0 : currentPage * ITEMS_PER_PAGE,
+      };
+
+      if (periodFilter !== 'all') params.period = periodFilter;
+      if (yearFilter) params.year = yearFilter;
+
+      if (reset) currentPage = 0;
+
+      const response = await journalSummariesApi.getJournalSummaries(params);
+      
+      if (reset) {
+        summaries = response.summaries;
+      } else {
+        summaries = [...summaries, ...response.summaries];
+      }
+      
+      totalSummaries = response.total;
+      hasMore = response.hasMore;
+    } catch (err) {
+      console.error('Failed to load journal summaries:', err);
+      error = err instanceof Error ? err.message : 'Failed to load journal summaries';
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function handleFilterChange() {
+    await loadSummaries(true);
+  }
+
+  async function loadMore() {
+    if (!hasMore || loading) return;
+    currentPage++;
+    await loadSummaries(false);
+  }
+
+  function createWeeklySummary() {
+    const { startDate, endDate } = journalSummariesUtils.getCurrentWeekBoundaries();
+    goto(`/journal-summaries/generate?period=week&startDate=${startDate}&endDate=${endDate}`);
+  }
+
+  function createMonthlySummary() {
+    const { startDate, endDate } = journalSummariesUtils.getCurrentMonthBoundaries();
+    goto(`/journal-summaries/generate?period=month&startDate=${startDate}&endDate=${endDate}`);
+  }
+
+  function viewSummary(summary: JournalSummaryResponse) {
+    goto(`/journal-summaries/${summary.id}`);
+  }
+
+  function getStatusBadgeClass(period: 'week' | 'month'): string {
+    return period === 'week' ? 'badge-primary' : 'badge-secondary';
+  }
+
+  // Get current year and a few previous years for filter
+  const currentYear = new Date().getFullYear();
+  const availableYears = Array.from({ length: 5 }, (_, i) => currentYear - i);
+</script>
+
+<svelte:head>
+  <title>Journal Summaries - Life Quest</title>
+</svelte:head>
+
+<div class="bg-base-100 min-h-screen">
+  <div class="mx-auto max-w-7xl px-4 py-8">
+    <!-- Header -->
+    <div class="mb-8">
+      <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div class="flex items-center gap-3">
+          <BookOpenIcon size={32} class="text-primary" />
+          <div>
+            <h1 class="text-gradient text-3xl font-bold">Journal Summaries</h1>
+            <p class="text-base-content/70">
+              {totalSummaries}
+              {totalSummaries === 1 ? 'summary' : 'summaries'} found
+            </p>
+          </div>
+        </div>
+
+        <div class="flex flex-wrap gap-2">
+          <button on:click={createWeeklySummary} class="btn btn-primary btn-sm gap-2">
+            <PlusIcon size={16} />
+            Weekly Summary
+          </button>
+          <button on:click={createMonthlySummary} class="btn btn-secondary btn-sm gap-2">
+            <PlusIcon size={16} />
+            Monthly Summary
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Filters -->
+    <div class="mb-6">
+      <div class="card bg-base-200">
+        <div class="card-body p-4">
+          <div class="flex flex-wrap items-center gap-4">
+            <div class="flex items-center gap-2">
+              <FilterIcon size={16} class="text-base-content/70" />
+              <span class="text-sm font-medium">Filters:</span>
+            </div>
+
+            <!-- Period Filter -->
+            <div class="form-control">
+              <label class="label py-0">
+                <span class="label-text text-xs">Period</span>
+              </label>
+              <select 
+                bind:value={periodFilter} 
+                on:change={handleFilterChange}
+                class="select select-bordered select-sm"
+              >
+                <option value="all">All Periods</option>
+                <option value="week">Weekly</option>
+                <option value="month">Monthly</option>
+              </select>
+            </div>
+
+            <!-- Year Filter -->
+            <div class="form-control">
+              <label class="label py-0">
+                <span class="label-text text-xs">Year</span>
+              </label>
+              <select 
+                bind:value={yearFilter} 
+                on:change={handleFilterChange}
+                class="select select-bordered select-sm"
+              >
+                <option value={null}>All Years</option>
+                {#each availableYears as year}
+                  <option value={year}>{year}</option>
+                {/each}
+              </select>
+            </div>
+
+            <button on:click={() => loadSummaries(true)} class="btn btn-ghost btn-sm gap-2">
+              <RefreshCwIcon size={14} />
+              Refresh
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Loading State -->
+    {#if loading && summaries.length === 0}
+      <div class="flex items-center justify-center py-20">
+        <div class="text-center">
+          <span class="loading loading-spinner loading-lg text-primary"></span>
+          <p class="text-base-content/60 mt-4">Loading summaries...</p>
+        </div>
+      </div>
+
+    <!-- Error State -->
+    {:else if error}
+      <div class="card bg-error text-error-content shadow-xl">
+        <div class="card-body text-center">
+          <h2 class="card-title justify-center">
+            <BookOpenIcon size={24} />
+            Error Loading Summaries
+          </h2>
+          <p>{error}</p>
+          <div class="card-actions justify-center">
+            <button on:click={() => loadSummaries(true)} class="btn btn-neutral">Try Again</button>
+          </div>
+        </div>
+      </div>
+
+    <!-- Empty State -->
+    {:else if summaries.length === 0}
+      <div class="card bg-base-200">
+        <div class="card-body py-20 text-center">
+          <div class="avatar placeholder mb-6">
+            <div class="bg-base-300 text-base-content w-24 rounded-full">
+              <BookOpenIcon size={48} />
+            </div>
+          </div>
+          <h2 class="text-2xl font-bold mb-4">No Journal Summaries Yet</h2>
+          <p class="text-base-content/70 mb-6 max-w-md mx-auto">
+            Create your first journal summary to see patterns and themes from your journal entries.
+          </p>
+          <div class="flex flex-wrap gap-3 justify-center">
+            <button on:click={createWeeklySummary} class="btn btn-primary gap-2">
+              <PlusIcon size={16} />
+              Create Weekly Summary
+            </button>
+            <button on:click={createMonthlySummary} class="btn btn-secondary gap-2">
+              <PlusIcon size={16} />
+              Create Monthly Summary
+            </button>
+          </div>
+        </div>
+      </div>
+
+    <!-- Summaries Grid -->
+    {:else}
+      <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+        {#each summaries as summary (summary.id)}
+          <div class="card bg-base-100 border-base-300 border shadow-xl hover:shadow-2xl transition-all duration-200 cursor-pointer" 
+               on:click={() => viewSummary(summary)}
+               on:keydown={(e) => e.key === 'Enter' && viewSummary(summary)}
+               role="button"
+               tabindex="0">
+            <div class="card-body">
+              <!-- Header -->
+              <div class="flex items-start justify-between mb-3">
+                <div class="flex items-center gap-2">
+                  <CalendarIcon size={18} class="text-base-content/70" />
+                  <span class="font-medium">
+                    {journalSummariesUtils.formatPeriod(summary.period, summary.startDate, summary.endDate)}
+                  </span>
+                </div>
+                <span class="badge {getStatusBadgeClass(summary.period)} badge-sm">
+                  {summary.period}
+                </span>
+              </div>
+
+              <!-- Summary Preview -->
+              <div class="flex-1">
+                <p class="text-base-content/80 text-sm line-clamp-4">
+                  {summary.summary.length > 200 ? summary.summary.substring(0, 200) + '...' : summary.summary}
+                </p>
+              </div>
+
+              <!-- Tags -->
+              {#if summary.tags && summary.tags.length > 0}
+                <div class="flex flex-wrap gap-1 mt-3">
+                  <TagIcon size={12} class="text-base-content/50 mt-0.5" />
+                  {#each summary.tags.slice(0, 3) as tag}
+                    <span class="badge badge-outline badge-xs">{tag}</span>
+                  {/each}
+                  {#if summary.tags.length > 3}
+                    <span class="badge badge-ghost badge-xs">+{summary.tags.length - 3}</span>
+                  {/if}
+                </div>
+              {/if}
+
+              <!-- Footer -->
+              <div class="flex items-center justify-between mt-4 pt-3 border-t border-base-300">
+                <div class="flex items-center gap-1 text-xs text-base-content/60">
+                  <ClockIcon size={12} />
+                  {formatDateTime(summary.createdAt)}
+                </div>
+                <div class="text-xs text-base-content/60">
+                  {summary.startDate} to {summary.endDate}
+                </div>
+              </div>
+            </div>
+          </div>
+        {/each}
+      </div>
+
+      <!-- Load More -->
+      {#if hasMore}
+        <div class="mt-8 text-center">
+          <button 
+            on:click={loadMore} 
+            disabled={loading}
+            class="btn btn-outline gap-2"
+          >
+            {#if loading}
+              <span class="loading loading-spinner loading-sm"></span>
+            {/if}
+            Load More Summaries
+          </button>
+        </div>
+      {/if}
+
+      <!-- Pagination Info -->
+      {#if totalSummaries > 0}
+        <div class="mt-6 text-center">
+          <p class="text-base-content/60 text-sm">
+            Showing {summaries.length} of {totalSummaries} summaries
+          </p>
+        </div>
+      {/if}
+    {/if}
+  </div>
+</div>
+
+<style>
+  .text-gradient {
+    background: linear-gradient(to right, oklch(0.637 0.237 25.331), oklch(0.637 0.237 330));
+    background-clip: text;
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+  }
+
+  .line-clamp-4 {
+    display: -webkit-box;
+    -webkit-line-clamp: 4;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+</style>

--- a/frontend/src/routes/journal-summaries/+page.svelte
+++ b/frontend/src/routes/journal-summaries/+page.svelte
@@ -3,17 +3,7 @@
   import { goto } from '$app/navigation';
   import { journalSummariesApi, journalSummariesUtils } from '$lib/api/journal-summaries';
   import type { JournalSummaryResponse, ListJournalSummariesResponse } from '$lib/types/journal-summaries';
-  import { 
-    BookOpenIcon, 
-    CalendarIcon, 
-    PlusIcon, 
-    FilterIcon, 
-    RefreshCwIcon,
-    ClockIcon,
-    TagIcon,
-    ChevronLeftIcon,
-    ChevronRightIcon
-  } from 'lucide-svelte';
+  import { BookOpenIcon, CalendarIcon, PlusIcon, FilterIcon, RefreshCwIcon, ClockIcon, TagIcon, ChevronLeftIcon, ChevronRightIcon } from 'lucide-svelte';
   import { formatDateTime } from '$lib/utils/date';
 
   // State
@@ -22,11 +12,11 @@
   let hasMore = false;
   let loading = true;
   let error: string | null = null;
-  
+
   // Filters
   let periodFilter: 'all' | 'week' | 'month' = 'all';
   let yearFilter: number | null = null;
-  
+
   // Pagination
   const ITEMS_PER_PAGE = 12;
   let currentPage = 0;
@@ -51,13 +41,13 @@
       if (reset) currentPage = 0;
 
       const response = await journalSummariesApi.getJournalSummaries(params);
-      
+
       if (reset) {
         summaries = response.summaries;
       } else {
         summaries = [...summaries, ...response.summaries];
       }
-      
+
       totalSummaries = response.total;
       hasMore = response.hasMore;
     } catch (err) {
@@ -149,11 +139,7 @@
               <label class="label py-0">
                 <span class="label-text text-xs">Period</span>
               </label>
-              <select 
-                bind:value={periodFilter} 
-                on:change={handleFilterChange}
-                class="select select-bordered select-sm"
-              >
+              <select bind:value={periodFilter} on:change={handleFilterChange} class="select select-bordered select-sm">
                 <option value="all">All Periods</option>
                 <option value="week">Weekly</option>
                 <option value="month">Monthly</option>
@@ -165,11 +151,7 @@
               <label class="label py-0">
                 <span class="label-text text-xs">Year</span>
               </label>
-              <select 
-                bind:value={yearFilter} 
-                on:change={handleFilterChange}
-                class="select select-bordered select-sm"
-              >
+              <select bind:value={yearFilter} on:change={handleFilterChange} class="select select-bordered select-sm">
                 <option value={null}>All Years</option>
                 {#each availableYears as year}
                   <option value={year}>{year}</option>
@@ -195,7 +177,7 @@
         </div>
       </div>
 
-    <!-- Error State -->
+      <!-- Error State -->
     {:else if error}
       <div class="card bg-error text-error-content shadow-xl">
         <div class="card-body text-center">
@@ -210,7 +192,7 @@
         </div>
       </div>
 
-    <!-- Empty State -->
+      <!-- Empty State -->
     {:else if summaries.length === 0}
       <div class="card bg-base-200">
         <div class="card-body py-20 text-center">
@@ -219,11 +201,9 @@
               <BookOpenIcon size={48} />
             </div>
           </div>
-          <h2 class="text-2xl font-bold mb-4">No Journal Summaries Yet</h2>
-          <p class="text-base-content/70 mb-6 max-w-md mx-auto">
-            Create your first journal summary to see patterns and themes from your journal entries.
-          </p>
-          <div class="flex flex-wrap gap-3 justify-center">
+          <h2 class="mb-4 text-2xl font-bold">No Journal Summaries Yet</h2>
+          <p class="text-base-content/70 mx-auto mb-6 max-w-md">Create your first journal summary to see patterns and themes from your journal entries.</p>
+          <div class="flex flex-wrap justify-center gap-3">
             <button on:click={createWeeklySummary} class="btn btn-primary gap-2">
               <PlusIcon size={16} />
               Create Weekly Summary
@@ -236,18 +216,20 @@
         </div>
       </div>
 
-    <!-- Summaries Grid -->
+      <!-- Summaries Grid -->
     {:else}
       <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
         {#each summaries as summary (summary.id)}
-          <div class="card bg-base-100 border-base-300 border shadow-xl hover:shadow-2xl transition-all duration-200 cursor-pointer" 
-               on:click={() => viewSummary(summary)}
-               on:keydown={(e) => e.key === 'Enter' && viewSummary(summary)}
-               role="button"
-               tabindex="0">
+          <div
+            class="card bg-base-100 border-base-300 cursor-pointer border shadow-xl transition-all duration-200 hover:shadow-2xl"
+            on:click={() => viewSummary(summary)}
+            on:keydown={(e) => e.key === 'Enter' && viewSummary(summary)}
+            role="button"
+            tabindex="0"
+          >
             <div class="card-body">
               <!-- Header -->
-              <div class="flex items-start justify-between mb-3">
+              <div class="mb-3 flex items-start justify-between">
                 <div class="flex items-center gap-2">
                   <CalendarIcon size={18} class="text-base-content/70" />
                   <span class="font-medium">
@@ -261,14 +243,14 @@
 
               <!-- Summary Preview -->
               <div class="flex-1">
-                <p class="text-base-content/80 text-sm line-clamp-4">
+                <p class="text-base-content/80 line-clamp-4 text-sm">
                   {summary.summary.length > 200 ? summary.summary.substring(0, 200) + '...' : summary.summary}
                 </p>
               </div>
 
               <!-- Tags -->
               {#if summary.tags && summary.tags.length > 0}
-                <div class="flex flex-wrap gap-1 mt-3">
+                <div class="mt-3 flex flex-wrap gap-1">
                   <TagIcon size={12} class="text-base-content/50 mt-0.5" />
                   {#each summary.tags.slice(0, 3) as tag}
                     <span class="badge badge-outline badge-xs">{tag}</span>
@@ -280,12 +262,12 @@
               {/if}
 
               <!-- Footer -->
-              <div class="flex items-center justify-between mt-4 pt-3 border-t border-base-300">
-                <div class="flex items-center gap-1 text-xs text-base-content/60">
+              <div class="border-base-300 mt-4 flex items-center justify-between border-t pt-3">
+                <div class="text-base-content/60 flex items-center gap-1 text-xs">
                   <ClockIcon size={12} />
                   {formatDateTime(summary.createdAt)}
                 </div>
-                <div class="text-xs text-base-content/60">
+                <div class="text-base-content/60 text-xs">
                   {summary.startDate} to {summary.endDate}
                 </div>
               </div>
@@ -297,11 +279,7 @@
       <!-- Load More -->
       {#if hasMore}
         <div class="mt-8 text-center">
-          <button 
-            on:click={loadMore} 
-            disabled={loading}
-            class="btn btn-outline gap-2"
-          >
+          <button on:click={loadMore} disabled={loading} class="btn btn-outline gap-2">
             {#if loading}
               <span class="loading loading-spinner loading-sm"></span>
             {/if}

--- a/frontend/src/routes/journal-summaries/[id]/+page.svelte
+++ b/frontend/src/routes/journal-summaries/[id]/+page.svelte
@@ -1,0 +1,256 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { page } from '$app/stores';
+  import { goto } from '$app/navigation';
+  import { journalSummariesApi, journalSummariesUtils } from '$lib/api/journal-summaries';
+  import type { JournalSummaryResponse } from '$lib/types/journal-summaries';
+  import { 
+    BookOpenIcon, 
+    CalendarIcon, 
+    ArrowLeftIcon,
+    EditIcon,
+    TrashIcon,
+    TagIcon,
+    ClockIcon
+  } from 'lucide-svelte';
+  import { formatDateTime } from '$lib/utils/date';
+
+  // State
+  let summary: JournalSummaryResponse | null = null;
+  let loading = true;
+  let error: string | null = null;
+  let showDeleteModal = false;
+  let deleting = false;
+
+  // Get the summary ID from the URL
+  $: summaryId = $page.params.id;
+
+  onMount(async () => {
+    if (summaryId) {
+      await loadSummary();
+    }
+  });
+
+  async function loadSummary() {
+    try {
+      loading = true;
+      error = null;
+      summary = await journalSummariesApi.getJournalSummary(summaryId);
+    } catch (err) {
+      console.error('Failed to load journal summary:', err);
+      error = err instanceof Error ? err.message : 'Failed to load journal summary';
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function deleteSummary() {
+    if (!summary) return;
+    
+    try {
+      deleting = true;
+      await journalSummariesApi.deleteJournalSummary(summary.id);
+      goto('/journal-summaries');
+    } catch (err) {
+      console.error('Failed to delete summary:', err);
+      error = err instanceof Error ? err.message : 'Failed to delete summary';
+    } finally {
+      deleting = false;
+      showDeleteModal = false;
+    }
+  }
+
+  function editSummary() {
+    if (!summary) return;
+    goto(`/journal-summaries/${summary.id}/edit`);
+  }
+
+  function goBack() {
+    goto('/journal-summaries');
+  }
+
+  function getStatusBadgeClass(period: 'week' | 'month'): string {
+    return period === 'week' ? 'badge-primary' : 'badge-secondary';
+  }
+
+  // Convert line breaks to paragraphs for better formatting
+  function formatSummaryContent(content: string): string {
+    return content
+      .split('\n\n')
+      .map(paragraph => `<p class="mb-4">${paragraph.replace(/\n/g, '<br>')}</p>`)
+      .join('');
+  }
+</script>
+
+<svelte:head>
+  <title>
+    {summary ? `${journalSummariesUtils.formatPeriod(summary.period, summary.startDate, summary.endDate)} Summary - Life Quest` : 'Journal Summary - Life Quest'}
+  </title>
+</svelte:head>
+
+<div class="bg-base-100 min-h-screen">
+  <div class="mx-auto max-w-4xl px-4 py-8">
+    <!-- Breadcrumb -->
+    <div class="breadcrumbs mb-6 text-sm">
+      <ul>
+        <li>
+          <button on:click={goBack} class="text-primary hover:text-primary-focus">
+            Journal Summaries
+          </button>
+        </li>
+        <li class="text-base-content/60">
+          {#if summary}
+            {journalSummariesUtils.formatPeriod(summary.period, summary.startDate, summary.endDate)}
+          {:else}
+            Loading...
+          {/if}
+        </li>
+      </ul>
+    </div>
+
+    <!-- Loading State -->
+    {#if loading}
+      <div class="flex items-center justify-center py-20">
+        <div class="text-center">
+          <span class="loading loading-spinner loading-lg text-primary"></span>
+          <p class="text-base-content/60 mt-4">Loading summary...</p>
+        </div>
+      </div>
+
+    <!-- Error State -->
+    {:else if error}
+      <div class="card bg-error text-error-content shadow-xl">
+        <div class="card-body text-center">
+          <h2 class="card-title justify-center">
+            <BookOpenIcon size={24} />
+            Error Loading Summary
+          </h2>
+          <p>{error}</p>
+          <div class="card-actions justify-center">
+            <button on:click={loadSummary} class="btn btn-neutral">Try Again</button>
+            <button on:click={goBack} class="btn btn-outline">Back to Summaries</button>
+          </div>
+        </div>
+      </div>
+
+    <!-- Summary Content -->
+    {:else if summary}
+      <div class="space-y-6">
+        <!-- Header Card -->
+        <div class="card bg-base-100 border-base-300 border shadow-xl">
+          <div class="card-body">
+            <div class="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+              <div class="flex-1">
+                <div class="flex items-center gap-3 mb-2">
+                  <CalendarIcon size={24} class="text-primary" />
+                  <h1 class="text-2xl font-bold">
+                    {journalSummariesUtils.formatPeriod(summary.period, summary.startDate, summary.endDate)}
+                  </h1>
+                  <span class="badge {getStatusBadgeClass(summary.period)}">
+                    {summary.period}
+                  </span>
+                </div>
+                <div class="flex items-center gap-4 text-sm text-base-content/70">
+                  <span>{summary.startDate} to {summary.endDate}</span>
+                  <div class="flex items-center gap-1">
+                    <ClockIcon size={14} />
+                    Created {formatDateTime(summary.createdAt)}
+                  </div>
+                </div>
+              </div>
+
+              <!-- Actions -->
+              <div class="flex gap-2">
+                <button on:click={editSummary} class="btn btn-outline btn-sm gap-2">
+                  <EditIcon size={16} />
+                  Edit
+                </button>
+                <button on:click={() => (showDeleteModal = true)} class="btn btn-outline btn-error btn-sm gap-2">
+                  <TrashIcon size={16} />
+                  Delete
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Tags -->
+        {#if summary.tags && summary.tags.length > 0}
+          <div class="card bg-base-100 border-base-300 border shadow-xl">
+            <div class="card-body">
+              <h2 class="card-title text-lg mb-4">
+                <TagIcon size={20} />
+                Tags
+              </h2>
+              <div class="flex flex-wrap gap-2">
+                {#each summary.tags as tag}
+                  <span class="badge badge-outline">{tag}</span>
+                {/each}
+              </div>
+            </div>
+          </div>
+        {/if}
+
+        <!-- Summary Content -->
+        <div class="card bg-base-100 border-base-300 border shadow-xl">
+          <div class="card-body">
+            <h2 class="card-title text-lg mb-4">
+              <BookOpenIcon size={20} />
+              Summary
+            </h2>
+            <div class="prose prose-sm max-w-none">
+              <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+              {@html formatSummaryContent(summary.summary)}
+            </div>
+          </div>
+        </div>
+
+        <!-- Back Button -->
+        <div class="text-center">
+          <button on:click={goBack} class="btn btn-outline gap-2">
+            <ArrowLeftIcon size={16} />
+            Back to Summaries
+          </button>
+        </div>
+      </div>
+    {/if}
+  </div>
+</div>
+
+<!-- Delete Confirmation Modal -->
+{#if showDeleteModal}
+  <div class="modal modal-open">
+    <div class="modal-box">
+      <h3 class="font-bold text-lg mb-4">Delete Summary</h3>
+      <p class="mb-6">
+        Are you sure you want to delete this journal summary? This action cannot be undone.
+      </p>
+      <div class="modal-action">
+        <button 
+          on:click={() => (showDeleteModal = false)} 
+          class="btn btn-outline"
+          disabled={deleting}
+        >
+          Cancel
+        </button>
+        <button 
+          on:click={deleteSummary} 
+          class="btn btn-error gap-2"
+          disabled={deleting}
+        >
+          {#if deleting}
+            <span class="loading loading-spinner loading-sm"></span>
+          {:else}
+            <TrashIcon size={16} />
+          {/if}
+          Delete Permanently
+        </button>
+      </div>
+    </div>
+    <button 
+      class="modal-backdrop" 
+      on:click={() => (showDeleteModal = false)} 
+      aria-label="Close modal"
+    ></button>
+  </div>
+{/if}

--- a/frontend/src/routes/journal-summaries/[id]/+page.svelte
+++ b/frontend/src/routes/journal-summaries/[id]/+page.svelte
@@ -4,15 +4,7 @@
   import { goto } from '$app/navigation';
   import { journalSummariesApi, journalSummariesUtils } from '$lib/api/journal-summaries';
   import type { JournalSummaryResponse } from '$lib/types/journal-summaries';
-  import { 
-    BookOpenIcon, 
-    CalendarIcon, 
-    ArrowLeftIcon,
-    EditIcon,
-    TrashIcon,
-    TagIcon,
-    ClockIcon
-  } from 'lucide-svelte';
+  import { BookOpenIcon, CalendarIcon, ArrowLeftIcon, EditIcon, TrashIcon, TagIcon, ClockIcon } from 'lucide-svelte';
   import { formatDateTime } from '$lib/utils/date';
 
   // State
@@ -46,7 +38,7 @@
 
   async function deleteSummary() {
     if (!summary) return;
-    
+
     try {
       deleting = true;
       await journalSummariesApi.deleteJournalSummary(summary.id);
@@ -77,14 +69,16 @@
   function formatSummaryContent(content: string): string {
     return content
       .split('\n\n')
-      .map(paragraph => `<p class="mb-4">${paragraph.replace(/\n/g, '<br>')}</p>`)
+      .map((paragraph) => `<p class="mb-4">${paragraph.replace(/\n/g, '<br>')}</p>`)
       .join('');
   }
 </script>
 
 <svelte:head>
   <title>
-    {summary ? `${journalSummariesUtils.formatPeriod(summary.period, summary.startDate, summary.endDate)} Summary - Life Quest` : 'Journal Summary - Life Quest'}
+    {summary
+      ? `${journalSummariesUtils.formatPeriod(summary.period, summary.startDate, summary.endDate)} Summary - Life Quest`
+      : 'Journal Summary - Life Quest'}
   </title>
 </svelte:head>
 
@@ -94,9 +88,7 @@
     <div class="breadcrumbs mb-6 text-sm">
       <ul>
         <li>
-          <button on:click={goBack} class="text-primary hover:text-primary-focus">
-            Journal Summaries
-          </button>
+          <button on:click={goBack} class="text-primary hover:text-primary-focus"> Journal Summaries </button>
         </li>
         <li class="text-base-content/60">
           {#if summary}
@@ -117,7 +109,7 @@
         </div>
       </div>
 
-    <!-- Error State -->
+      <!-- Error State -->
     {:else if error}
       <div class="card bg-error text-error-content shadow-xl">
         <div class="card-body text-center">
@@ -133,7 +125,7 @@
         </div>
       </div>
 
-    <!-- Summary Content -->
+      <!-- Summary Content -->
     {:else if summary}
       <div class="space-y-6">
         <!-- Header Card -->
@@ -141,7 +133,7 @@
           <div class="card-body">
             <div class="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
               <div class="flex-1">
-                <div class="flex items-center gap-3 mb-2">
+                <div class="mb-2 flex items-center gap-3">
                   <CalendarIcon size={24} class="text-primary" />
                   <h1 class="text-2xl font-bold">
                     {journalSummariesUtils.formatPeriod(summary.period, summary.startDate, summary.endDate)}
@@ -150,7 +142,7 @@
                     {summary.period}
                   </span>
                 </div>
-                <div class="flex items-center gap-4 text-sm text-base-content/70">
+                <div class="text-base-content/70 flex items-center gap-4 text-sm">
                   <span>{summary.startDate} to {summary.endDate}</span>
                   <div class="flex items-center gap-1">
                     <ClockIcon size={14} />
@@ -178,7 +170,7 @@
         {#if summary.tags && summary.tags.length > 0}
           <div class="card bg-base-100 border-base-300 border shadow-xl">
             <div class="card-body">
-              <h2 class="card-title text-lg mb-4">
+              <h2 class="card-title mb-4 text-lg">
                 <TagIcon size={20} />
                 Tags
               </h2>
@@ -194,7 +186,7 @@
         <!-- Summary Content -->
         <div class="card bg-base-100 border-base-300 border shadow-xl">
           <div class="card-body">
-            <h2 class="card-title text-lg mb-4">
+            <h2 class="card-title mb-4 text-lg">
               <BookOpenIcon size={20} />
               Summary
             </h2>
@@ -221,23 +213,11 @@
 {#if showDeleteModal}
   <div class="modal modal-open">
     <div class="modal-box">
-      <h3 class="font-bold text-lg mb-4">Delete Summary</h3>
-      <p class="mb-6">
-        Are you sure you want to delete this journal summary? This action cannot be undone.
-      </p>
+      <h3 class="mb-4 text-lg font-bold">Delete Summary</h3>
+      <p class="mb-6">Are you sure you want to delete this journal summary? This action cannot be undone.</p>
       <div class="modal-action">
-        <button 
-          on:click={() => (showDeleteModal = false)} 
-          class="btn btn-outline"
-          disabled={deleting}
-        >
-          Cancel
-        </button>
-        <button 
-          on:click={deleteSummary} 
-          class="btn btn-error gap-2"
-          disabled={deleting}
-        >
+        <button on:click={() => (showDeleteModal = false)} class="btn btn-outline" disabled={deleting}> Cancel </button>
+        <button on:click={deleteSummary} class="btn btn-error gap-2" disabled={deleting}>
           {#if deleting}
             <span class="loading loading-spinner loading-sm"></span>
           {:else}
@@ -247,10 +227,6 @@
         </button>
       </div>
     </div>
-    <button 
-      class="modal-backdrop" 
-      on:click={() => (showDeleteModal = false)} 
-      aria-label="Close modal"
-    ></button>
+    <button class="modal-backdrop" on:click={() => (showDeleteModal = false)} aria-label="Close modal"></button>
   </div>
 {/if}

--- a/frontend/src/routes/journal-summaries/[id]/edit/+page.svelte
+++ b/frontend/src/routes/journal-summaries/[id]/edit/+page.svelte
@@ -4,13 +4,7 @@
   import { goto } from '$app/navigation';
   import { journalSummariesApi, journalSummariesUtils } from '$lib/api/journal-summaries';
   import type { JournalSummaryResponse, UpdateJournalSummaryFormData } from '$lib/types/journal-summaries';
-  import { 
-    BookOpenIcon, 
-    CalendarIcon, 
-    ArrowLeftIcon,
-    SaveIcon,
-    TagIcon
-  } from 'lucide-svelte';
+  import { BookOpenIcon, CalendarIcon, ArrowLeftIcon, SaveIcon, TagIcon } from 'lucide-svelte';
 
   // State
   let summary: JournalSummaryResponse | null = null;
@@ -34,7 +28,7 @@
       loading = true;
       error = null;
       summary = await journalSummariesApi.getJournalSummary(summaryId);
-      
+
       if (summary) {
         formData = {
           summary: summary.summary,
@@ -60,8 +54,8 @@
       // Parse tags from input
       const tags = tagsInput
         .split(',')
-        .map(tag => tag.trim())
-        .filter(tag => tag.length > 0);
+        .map((tag) => tag.trim())
+        .filter((tag) => tag.length > 0);
 
       const updateData: UpdateJournalSummaryFormData = {
         summary: formData.summary,
@@ -97,7 +91,9 @@
 
 <svelte:head>
   <title>
-    {summary ? `Edit ${journalSummariesUtils.formatPeriod(summary.period, summary.startDate, summary.endDate)} Summary - Life Quest` : 'Edit Summary - Life Quest'}
+    {summary
+      ? `Edit ${journalSummariesUtils.formatPeriod(summary.period, summary.startDate, summary.endDate)} Summary - Life Quest`
+      : 'Edit Summary - Life Quest'}
   </title>
 </svelte:head>
 
@@ -107,9 +103,7 @@
     <div class="breadcrumbs mb-6 text-sm">
       <ul>
         <li>
-          <button on:click={() => goto('/journal-summaries')} class="text-primary hover:text-primary-focus">
-            Journal Summaries
-          </button>
+          <button on:click={() => goto('/journal-summaries')} class="text-primary hover:text-primary-focus"> Journal Summaries </button>
         </li>
         <li>
           <button on:click={goBack} class="text-primary hover:text-primary-focus">
@@ -129,7 +123,7 @@
         </div>
       </div>
 
-    <!-- Error State -->
+      <!-- Error State -->
     {:else if error && !summary}
       <div class="card bg-error text-error-content shadow-xl">
         <div class="card-body text-center">
@@ -145,13 +139,13 @@
         </div>
       </div>
 
-    <!-- Edit Form -->
+      <!-- Edit Form -->
     {:else if summary}
       <div class="space-y-6">
         <!-- Header -->
         <div class="card bg-base-100 border-base-300 border shadow-xl">
           <div class="card-body">
-            <div class="flex items-center gap-3 mb-2">
+            <div class="mb-2 flex items-center gap-3">
               <CalendarIcon size={24} class="text-primary" />
               <h1 class="text-2xl font-bold">
                 Edit {journalSummariesUtils.formatPeriod(summary.period, summary.startDate, summary.endDate)}
@@ -160,7 +154,7 @@
                 {summary.period}
               </span>
             </div>
-            <div class="text-sm text-base-content/70">
+            <div class="text-base-content/70 text-sm">
               {summary.startDate} to {summary.endDate}
             </div>
           </div>
@@ -175,7 +169,7 @@
                 <label for="summary-content" class="label">
                   <span class="label-text font-medium">Summary Content</span>
                 </label>
-                <textarea 
+                <textarea
                   id="summary-content"
                   bind:value={formData.summary}
                   class="textarea textarea-bordered h-48"
@@ -192,9 +186,9 @@
                 <label for="tags-input" class="label">
                   <span class="label-text font-medium">Tags</span>
                 </label>
-                <input 
+                <input
                   id="tags-input"
-                  type="text" 
+                  type="text"
                   bind:value={tagsInput}
                   class="input input-bordered"
                   placeholder="productivity, health, goals (comma-separated)"
@@ -213,11 +207,7 @@
 
               <!-- Actions -->
               <div class="flex flex-col gap-3 sm:flex-row-reverse">
-                <button 
-                  type="submit" 
-                  disabled={!isValid()} 
-                  class="btn btn-primary gap-2 flex-1 sm:flex-none"
-                >
+                <button type="submit" disabled={!isValid()} class="btn btn-primary flex-1 gap-2 sm:flex-none">
                   {#if saving}
                     <span class="loading loading-spinner loading-sm"></span>
                     Saving...
@@ -226,12 +216,7 @@
                     Save Changes
                   {/if}
                 </button>
-                <button 
-                  type="button" 
-                  on:click={goBack} 
-                  class="btn btn-outline flex-1 sm:flex-none"
-                  disabled={saving}
-                >
+                <button type="button" on:click={goBack} class="btn btn-outline flex-1 sm:flex-none" disabled={saving}>
                   <ArrowLeftIcon size={16} />
                   Cancel
                 </button>
@@ -244,20 +229,23 @@
         {#if formData.summary && formData.summary.trim().length > 0}
           <div class="card bg-base-200 border-base-300 border">
             <div class="card-body">
-              <h3 class="card-title text-lg mb-4">
+              <h3 class="card-title mb-4 text-lg">
                 <BookOpenIcon size={20} />
                 Preview
               </h3>
-              
+
               <!-- Tags Preview -->
               {#if tagsInput.trim()}
                 <div class="mb-4">
-                  <div class="flex items-center gap-2 mb-2">
+                  <div class="mb-2 flex items-center gap-2">
                     <TagIcon size={16} class="text-base-content/70" />
                     <span class="text-sm font-medium">Tags:</span>
                   </div>
                   <div class="flex flex-wrap gap-2">
-                    {#each tagsInput.split(',').map(tag => tag.trim()).filter(tag => tag.length > 0) as tag}
+                    {#each tagsInput
+                      .split(',')
+                      .map((tag) => tag.trim())
+                      .filter((tag) => tag.length > 0) as tag}
                       <span class="badge badge-outline badge-sm">{tag}</span>
                     {/each}
                   </div>

--- a/frontend/src/routes/journal-summaries/[id]/edit/+page.svelte
+++ b/frontend/src/routes/journal-summaries/[id]/edit/+page.svelte
@@ -1,0 +1,281 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { page } from '$app/stores';
+  import { goto } from '$app/navigation';
+  import { journalSummariesApi, journalSummariesUtils } from '$lib/api/journal-summaries';
+  import type { JournalSummaryResponse, UpdateJournalSummaryFormData } from '$lib/types/journal-summaries';
+  import { 
+    BookOpenIcon, 
+    CalendarIcon, 
+    ArrowLeftIcon,
+    SaveIcon,
+    TagIcon
+  } from 'lucide-svelte';
+
+  // State
+  let summary: JournalSummaryResponse | null = null;
+  let formData: UpdateJournalSummaryFormData = {};
+  let loading = true;
+  let saving = false;
+  let error: string | null = null;
+  let tagsInput = '';
+
+  // Get the summary ID from the URL
+  $: summaryId = $page.params.id;
+
+  onMount(async () => {
+    if (summaryId) {
+      await loadSummary();
+    }
+  });
+
+  async function loadSummary() {
+    try {
+      loading = true;
+      error = null;
+      summary = await journalSummariesApi.getJournalSummary(summaryId);
+      
+      if (summary) {
+        formData = {
+          summary: summary.summary,
+          tags: summary.tags || [],
+        };
+        tagsInput = summary.tags ? summary.tags.join(', ') : '';
+      }
+    } catch (err) {
+      console.error('Failed to load journal summary:', err);
+      error = err instanceof Error ? err.message : 'Failed to load journal summary';
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function saveSummary() {
+    if (!summary) return;
+
+    try {
+      saving = true;
+      error = null;
+
+      // Parse tags from input
+      const tags = tagsInput
+        .split(',')
+        .map(tag => tag.trim())
+        .filter(tag => tag.length > 0);
+
+      const updateData: UpdateJournalSummaryFormData = {
+        summary: formData.summary,
+        tags: tags.length > 0 ? tags : undefined,
+      };
+
+      const updatedSummary = await journalSummariesApi.updateJournalSummary(summary.id, updateData);
+      goto(`/journal-summaries/${updatedSummary.id}`);
+    } catch (err) {
+      console.error('Failed to save summary:', err);
+      error = err instanceof Error ? err.message : 'Failed to save summary';
+    } finally {
+      saving = false;
+    }
+  }
+
+  function goBack() {
+    if (summary) {
+      goto(`/journal-summaries/${summary.id}`);
+    } else {
+      goto('/journal-summaries');
+    }
+  }
+
+  function getStatusBadgeClass(period: 'week' | 'month'): string {
+    return period === 'week' ? 'badge-primary' : 'badge-secondary';
+  }
+
+  function isValid(): boolean {
+    return Boolean(formData.summary && formData.summary.trim().length > 0) && !saving;
+  }
+</script>
+
+<svelte:head>
+  <title>
+    {summary ? `Edit ${journalSummariesUtils.formatPeriod(summary.period, summary.startDate, summary.endDate)} Summary - Life Quest` : 'Edit Summary - Life Quest'}
+  </title>
+</svelte:head>
+
+<div class="bg-base-100 min-h-screen">
+  <div class="mx-auto max-w-4xl px-4 py-8">
+    <!-- Breadcrumb -->
+    <div class="breadcrumbs mb-6 text-sm">
+      <ul>
+        <li>
+          <button on:click={() => goto('/journal-summaries')} class="text-primary hover:text-primary-focus">
+            Journal Summaries
+          </button>
+        </li>
+        <li>
+          <button on:click={goBack} class="text-primary hover:text-primary-focus">
+            {summary ? journalSummariesUtils.formatPeriod(summary.period, summary.startDate, summary.endDate) : 'Summary'}
+          </button>
+        </li>
+        <li class="text-base-content/60">Edit</li>
+      </ul>
+    </div>
+
+    <!-- Loading State -->
+    {#if loading}
+      <div class="flex items-center justify-center py-20">
+        <div class="text-center">
+          <span class="loading loading-spinner loading-lg text-primary"></span>
+          <p class="text-base-content/60 mt-4">Loading summary...</p>
+        </div>
+      </div>
+
+    <!-- Error State -->
+    {:else if error && !summary}
+      <div class="card bg-error text-error-content shadow-xl">
+        <div class="card-body text-center">
+          <h2 class="card-title justify-center">
+            <BookOpenIcon size={24} />
+            Error Loading Summary
+          </h2>
+          <p>{error}</p>
+          <div class="card-actions justify-center">
+            <button on:click={loadSummary} class="btn btn-neutral">Try Again</button>
+            <button on:click={() => goto('/journal-summaries')} class="btn btn-outline">Back to Summaries</button>
+          </div>
+        </div>
+      </div>
+
+    <!-- Edit Form -->
+    {:else if summary}
+      <div class="space-y-6">
+        <!-- Header -->
+        <div class="card bg-base-100 border-base-300 border shadow-xl">
+          <div class="card-body">
+            <div class="flex items-center gap-3 mb-2">
+              <CalendarIcon size={24} class="text-primary" />
+              <h1 class="text-2xl font-bold">
+                Edit {journalSummariesUtils.formatPeriod(summary.period, summary.startDate, summary.endDate)}
+              </h1>
+              <span class="badge {getStatusBadgeClass(summary.period)}">
+                {summary.period}
+              </span>
+            </div>
+            <div class="text-sm text-base-content/70">
+              {summary.startDate} to {summary.endDate}
+            </div>
+          </div>
+        </div>
+
+        <!-- Edit Form -->
+        <div class="card bg-base-100 border-base-300 border shadow-xl">
+          <div class="card-body">
+            <form on:submit|preventDefault={saveSummary} class="space-y-6">
+              <!-- Summary Content -->
+              <div class="form-control">
+                <label for="summary-content" class="label">
+                  <span class="label-text font-medium">Summary Content</span>
+                </label>
+                <textarea 
+                  id="summary-content"
+                  bind:value={formData.summary}
+                  class="textarea textarea-bordered h-48"
+                  placeholder="Write your summary here..."
+                  required
+                ></textarea>
+                <div class="label">
+                  <span class="label-text-alt">Use clear, descriptive language to capture the key themes and insights</span>
+                </div>
+              </div>
+
+              <!-- Tags -->
+              <div class="form-control">
+                <label for="tags-input" class="label">
+                  <span class="label-text font-medium">Tags</span>
+                </label>
+                <input 
+                  id="tags-input"
+                  type="text" 
+                  bind:value={tagsInput}
+                  class="input input-bordered"
+                  placeholder="productivity, health, goals (comma-separated)"
+                />
+                <div class="label">
+                  <span class="label-text-alt">Separate tags with commas</span>
+                </div>
+              </div>
+
+              <!-- Error Message -->
+              {#if error}
+                <div class="alert alert-error">
+                  <span>{error}</span>
+                </div>
+              {/if}
+
+              <!-- Actions -->
+              <div class="flex flex-col gap-3 sm:flex-row-reverse">
+                <button 
+                  type="submit" 
+                  disabled={!isValid()} 
+                  class="btn btn-primary gap-2 flex-1 sm:flex-none"
+                >
+                  {#if saving}
+                    <span class="loading loading-spinner loading-sm"></span>
+                    Saving...
+                  {:else}
+                    <SaveIcon size={16} />
+                    Save Changes
+                  {/if}
+                </button>
+                <button 
+                  type="button" 
+                  on:click={goBack} 
+                  class="btn btn-outline flex-1 sm:flex-none"
+                  disabled={saving}
+                >
+                  <ArrowLeftIcon size={16} />
+                  Cancel
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+
+        <!-- Preview Section -->
+        {#if formData.summary && formData.summary.trim().length > 0}
+          <div class="card bg-base-200 border-base-300 border">
+            <div class="card-body">
+              <h3 class="card-title text-lg mb-4">
+                <BookOpenIcon size={20} />
+                Preview
+              </h3>
+              
+              <!-- Tags Preview -->
+              {#if tagsInput.trim()}
+                <div class="mb-4">
+                  <div class="flex items-center gap-2 mb-2">
+                    <TagIcon size={16} class="text-base-content/70" />
+                    <span class="text-sm font-medium">Tags:</span>
+                  </div>
+                  <div class="flex flex-wrap gap-2">
+                    {#each tagsInput.split(',').map(tag => tag.trim()).filter(tag => tag.length > 0) as tag}
+                      <span class="badge badge-outline badge-sm">{tag}</span>
+                    {/each}
+                  </div>
+                </div>
+              {/if}
+
+              <!-- Summary Preview -->
+              <div class="prose prose-sm max-w-none">
+                {#each formData.summary.split('\n\n') as paragraph}
+                  {#if paragraph.trim()}
+                    <p>{paragraph.replace(/\n/g, ' ')}</p>
+                  {/if}
+                {/each}
+              </div>
+            </div>
+          </div>
+        {/if}
+      </div>
+    {/if}
+  </div>
+</div>

--- a/frontend/src/routes/journal-summaries/generate/+page.svelte
+++ b/frontend/src/routes/journal-summaries/generate/+page.svelte
@@ -34,8 +34,11 @@
     } else {
       // Default to current week
       const boundaries = journalSummariesUtils.getCurrentWeekBoundaries();
-      formData.startDate = boundaries.startDate;
-      formData.endDate = boundaries.endDate;
+      formData = {
+        ...formData,
+        startDate: boundaries.startDate,
+        endDate: boundaries.endDate
+      };
     }
   });
 
@@ -63,12 +66,18 @@
     const now = new Date();
     if (formData.period === 'week') {
       const boundaries = journalSummariesUtils.getWeekBoundaries(now);
-      formData.startDate = boundaries.startDate;
-      formData.endDate = boundaries.endDate;
+      formData = {
+        ...formData,
+        startDate: boundaries.startDate,
+        endDate: boundaries.endDate
+      };
     } else {
       const boundaries = journalSummariesUtils.getMonthBoundaries(now);
-      formData.startDate = boundaries.startDate;
-      formData.endDate = boundaries.endDate;
+      formData = {
+        ...formData,
+        startDate: boundaries.startDate,
+        endDate: boundaries.endDate
+      };
     }
   }
 
@@ -84,19 +93,23 @@
       previousDate = new Date(startDate);
       previousDate.setDate(startDate.getDate() - 7);
       const boundaries = journalSummariesUtils.getWeekBoundaries(previousDate);
-      formData.startDate = boundaries.startDate;
-      formData.endDate = boundaries.endDate;
+      formData = {
+        ...formData,
+        startDate: boundaries.startDate,
+        endDate: boundaries.endDate
+      };
     } else {
       previousDate = new Date(startDate.getFullYear(), startDate.getMonth() - 1, 1);
       const boundaries = journalSummariesUtils.getMonthBoundaries(previousDate);
-      formData.startDate = boundaries.startDate;
-      formData.endDate = boundaries.endDate;
+      formData = {
+        ...formData,
+        startDate: boundaries.startDate,
+        endDate: boundaries.endDate
+      };
     }
   }
 
-  function isValid(): boolean {
-    return Boolean(formData.startDate && formData.endDate && formData.period) && !generating;
-  }
+  $: isFormValid = Boolean(formData.startDate && formData.endDate && formData.period) && !generating;
 
   $: periodLabel = formData.period === 'week' ? 'Weekly' : 'Monthly';
   $: dateRangeLabel = formData.startDate && formData.endDate 
@@ -245,7 +258,7 @@
           <div class="flex flex-col gap-3 sm:flex-row-reverse">
             <button 
               type="submit" 
-              disabled={!isValid()} 
+              disabled={!isFormValid} 
               class="btn btn-primary gap-2 flex-1 sm:flex-none"
             >
               {#if generating}

--- a/frontend/src/routes/journal-summaries/generate/+page.svelte
+++ b/frontend/src/routes/journal-summaries/generate/+page.svelte
@@ -1,0 +1,281 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { page } from '$app/stores';
+  import { goto } from '$app/navigation';
+  import { journalSummariesApi, journalSummariesUtils } from '$lib/api/journal-summaries';
+  import type { GenerateJournalSummaryFormData } from '$lib/types/journal-summaries';
+  import { 
+    BookOpenIcon, 
+    CalendarIcon, 
+    ArrowLeftIcon,
+    SparklesIcon,
+    SaveIcon,
+    ClockIcon
+  } from 'lucide-svelte';
+
+  // State
+  let formData: GenerateJournalSummaryFormData = {
+    period: 'week',
+    startDate: '',
+    endDate: '',
+  };
+  let generating = false;
+  let error: string | null = null;
+
+  onMount(() => {
+    // Get parameters from URL if present
+    const urlParams = $page.url.searchParams;
+    const period = urlParams.get('period') as 'week' | 'month' | null;
+    const startDate = urlParams.get('startDate');
+    const endDate = urlParams.get('endDate');
+
+    if (period && startDate && endDate) {
+      formData = { period, startDate, endDate };
+    } else {
+      // Default to current week
+      const boundaries = journalSummariesUtils.getCurrentWeekBoundaries();
+      formData.startDate = boundaries.startDate;
+      formData.endDate = boundaries.endDate;
+    }
+  });
+
+  async function generateSummary() {
+    try {
+      generating = true;
+      error = null;
+
+      const summary = await journalSummariesApi.generateJournalSummary(formData);
+      goto(`/journal-summaries/${summary.id}`);
+    } catch (err) {
+      console.error('Failed to generate summary:', err);
+      error = err instanceof Error ? err.message : 'Failed to generate summary';
+    } finally {
+      generating = false;
+    }
+  }
+
+  function goBack() {
+    goto('/journal-summaries');
+  }
+
+  function handlePeriodChange() {
+    // Update date boundaries when period changes
+    const now = new Date();
+    if (formData.period === 'week') {
+      const boundaries = journalSummariesUtils.getWeekBoundaries(now);
+      formData.startDate = boundaries.startDate;
+      formData.endDate = boundaries.endDate;
+    } else {
+      const boundaries = journalSummariesUtils.getMonthBoundaries(now);
+      formData.startDate = boundaries.startDate;
+      formData.endDate = boundaries.endDate;
+    }
+  }
+
+  function setCurrentPeriod() {
+    handlePeriodChange();
+  }
+
+  function setPreviousPeriod() {
+    const startDate = new Date(formData.startDate);
+    let previousDate: Date;
+
+    if (formData.period === 'week') {
+      previousDate = new Date(startDate);
+      previousDate.setDate(startDate.getDate() - 7);
+      const boundaries = journalSummariesUtils.getWeekBoundaries(previousDate);
+      formData.startDate = boundaries.startDate;
+      formData.endDate = boundaries.endDate;
+    } else {
+      previousDate = new Date(startDate.getFullYear(), startDate.getMonth() - 1, 1);
+      const boundaries = journalSummariesUtils.getMonthBoundaries(previousDate);
+      formData.startDate = boundaries.startDate;
+      formData.endDate = boundaries.endDate;
+    }
+  }
+
+  function isValid(): boolean {
+    return Boolean(formData.startDate && formData.endDate && formData.period) && !generating;
+  }
+
+  $: periodLabel = formData.period === 'week' ? 'Weekly' : 'Monthly';
+  $: dateRangeLabel = formData.startDate && formData.endDate 
+    ? journalSummariesUtils.formatPeriod(formData.period, formData.startDate, formData.endDate)
+    : 'Select dates';
+</script>
+
+<svelte:head>
+  <title>Generate Journal Summary - Life Quest</title>
+</svelte:head>
+
+<div class="bg-base-100 min-h-screen">
+  <div class="mx-auto max-w-2xl px-4 py-8">
+    <!-- Breadcrumb -->
+    <div class="breadcrumbs mb-6 text-sm">
+      <ul>
+        <li>
+          <button on:click={goBack} class="text-primary hover:text-primary-focus">
+            Journal Summaries
+          </button>
+        </li>
+        <li class="text-base-content/60">Generate New Summary</li>
+      </ul>
+    </div>
+
+    <!-- Header -->
+    <div class="mb-8 text-center">
+      <div class="flex items-center justify-center gap-3 mb-4">
+        <SparklesIcon size={32} class="text-primary" />
+        <h1 class="text-3xl font-bold">Generate Summary</h1>
+      </div>
+      <p class="text-base-content/70">
+        Create an AI-generated summary of your journal entries for a specific time period
+      </p>
+    </div>
+
+    <!-- Form -->
+    <div class="card bg-base-100 border-base-300 border shadow-xl">
+      <div class="card-body">
+        <form on:submit|preventDefault={generateSummary} class="space-y-6">
+          <!-- Period Selection -->
+          <div class="form-control">
+            <span class="label-text font-medium mb-2 block">Summary Period</span>
+            <div class="flex gap-4">
+              <label class="label cursor-pointer">
+                <input 
+                  type="radio" 
+                  bind:group={formData.period} 
+                  value="week"
+                  on:change={handlePeriodChange}
+                  class="radio radio-primary" 
+                />
+                <span class="label-text ml-2">Weekly</span>
+              </label>
+              <label class="label cursor-pointer">
+                <input 
+                  type="radio" 
+                  bind:group={formData.period} 
+                  value="month"
+                  on:change={handlePeriodChange}
+                  class="radio radio-secondary" 
+                />
+                <span class="label-text ml-2">Monthly</span>
+              </label>
+            </div>
+          </div>
+
+          <!-- Date Range Preview -->
+          <div class="alert alert-info">
+            <CalendarIcon size={20} />
+            <div>
+              <h4 class="font-medium">{periodLabel} Summary</h4>
+              <p class="text-sm opacity-75">{dateRangeLabel}</p>
+            </div>
+          </div>
+
+          <!-- Date Range Inputs -->
+          <div class="grid grid-cols-2 gap-4">
+            <div class="form-control">
+              <label for="start-date" class="label">
+                <span class="label-text">Start Date</span>
+              </label>
+              <input 
+                id="start-date"
+                type="date" 
+                bind:value={formData.startDate}
+                class="input input-bordered"
+                required 
+              />
+            </div>
+            <div class="form-control">
+              <label for="end-date" class="label">
+                <span class="label-text">End Date</span>
+              </label>
+              <input 
+                id="end-date"
+                type="date" 
+                bind:value={formData.endDate}
+                class="input input-bordered"
+                required 
+              />
+            </div>
+          </div>
+
+          <!-- Quick Date Presets -->
+          <div class="form-control">
+            <span class="label-text mb-2 block">Quick Presets</span>
+            <div class="flex flex-wrap gap-2">
+              <button 
+                type="button" 
+                on:click={setCurrentPeriod}
+                class="btn btn-outline btn-sm"
+              >
+                Current {formData.period === 'week' ? 'Week' : 'Month'}
+              </button>
+              <button 
+                type="button" 
+                on:click={setPreviousPeriod}
+                class="btn btn-outline btn-sm"
+              >
+                Previous {formData.period === 'week' ? 'Week' : 'Month'}
+              </button>
+            </div>
+          </div>
+
+          <!-- Error Message -->
+          {#if error}
+            <div class="alert alert-error">
+              <span>{error}</span>
+            </div>
+          {/if}
+
+          <!-- Info Box -->
+          <div class="alert">
+            <BookOpenIcon size={20} />
+            <div>
+              <h4 class="font-medium">How it works</h4>
+              <p class="text-sm opacity-75">
+                We'll analyze all your completed journal entries from the selected period and create a cohesive summary 
+                highlighting key themes, patterns, and insights.
+              </p>
+            </div>
+          </div>
+
+          <!-- Actions -->
+          <div class="flex flex-col gap-3 sm:flex-row-reverse">
+            <button 
+              type="submit" 
+              disabled={!isValid()} 
+              class="btn btn-primary gap-2 flex-1 sm:flex-none"
+            >
+              {#if generating}
+                <span class="loading loading-spinner loading-sm"></span>
+                Generating...
+              {:else}
+                <SparklesIcon size={16} />
+                Generate Summary
+              {/if}
+            </button>
+            <button 
+              type="button" 
+              on:click={goBack} 
+              class="btn btn-outline flex-1 sm:flex-none"
+              disabled={generating}
+            >
+              <ArrowLeftIcon size={16} />
+              Cancel
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+
+    <!-- Additional Info -->
+    <div class="mt-8 text-center">
+      <div class="text-sm text-base-content/60">
+        <ClockIcon size={14} class="inline mr-1" />
+        Summary generation typically takes 10-30 seconds
+      </div>
+    </div>
+  </div>
+</div>

--- a/frontend/src/routes/journal-summaries/generate/+page.svelte
+++ b/frontend/src/routes/journal-summaries/generate/+page.svelte
@@ -4,14 +4,7 @@
   import { goto } from '$app/navigation';
   import { journalSummariesApi, journalSummariesUtils } from '$lib/api/journal-summaries';
   import type { GenerateJournalSummaryFormData } from '$lib/types/journal-summaries';
-  import { 
-    BookOpenIcon, 
-    CalendarIcon, 
-    ArrowLeftIcon,
-    SparklesIcon,
-    SaveIcon,
-    ClockIcon
-  } from 'lucide-svelte';
+  import { BookOpenIcon, CalendarIcon, ArrowLeftIcon, SparklesIcon, SaveIcon, ClockIcon } from 'lucide-svelte';
 
   // State
   let formData: GenerateJournalSummaryFormData = {
@@ -37,7 +30,7 @@
       formData = {
         ...formData,
         startDate: boundaries.startDate,
-        endDate: boundaries.endDate
+        endDate: boundaries.endDate,
       };
     }
   });
@@ -69,14 +62,14 @@
       formData = {
         ...formData,
         startDate: boundaries.startDate,
-        endDate: boundaries.endDate
+        endDate: boundaries.endDate,
       };
     } else {
       const boundaries = journalSummariesUtils.getMonthBoundaries(now);
       formData = {
         ...formData,
         startDate: boundaries.startDate,
-        endDate: boundaries.endDate
+        endDate: boundaries.endDate,
       };
     }
   }
@@ -96,7 +89,7 @@
       formData = {
         ...formData,
         startDate: boundaries.startDate,
-        endDate: boundaries.endDate
+        endDate: boundaries.endDate,
       };
     } else {
       previousDate = new Date(startDate.getFullYear(), startDate.getMonth() - 1, 1);
@@ -104,7 +97,7 @@
       formData = {
         ...formData,
         startDate: boundaries.startDate,
-        endDate: boundaries.endDate
+        endDate: boundaries.endDate,
       };
     }
   }
@@ -112,9 +105,8 @@
   $: isFormValid = Boolean(formData.startDate && formData.endDate && formData.period) && !generating;
 
   $: periodLabel = formData.period === 'week' ? 'Weekly' : 'Monthly';
-  $: dateRangeLabel = formData.startDate && formData.endDate 
-    ? journalSummariesUtils.formatPeriod(formData.period, formData.startDate, formData.endDate)
-    : 'Select dates';
+  $: dateRangeLabel =
+    formData.startDate && formData.endDate ? journalSummariesUtils.formatPeriod(formData.period, formData.startDate, formData.endDate) : 'Select dates';
 </script>
 
 <svelte:head>
@@ -127,9 +119,7 @@
     <div class="breadcrumbs mb-6 text-sm">
       <ul>
         <li>
-          <button on:click={goBack} class="text-primary hover:text-primary-focus">
-            Journal Summaries
-          </button>
+          <button on:click={goBack} class="text-primary hover:text-primary-focus"> Journal Summaries </button>
         </li>
         <li class="text-base-content/60">Generate New Summary</li>
       </ul>
@@ -137,13 +127,11 @@
 
     <!-- Header -->
     <div class="mb-8 text-center">
-      <div class="flex items-center justify-center gap-3 mb-4">
+      <div class="mb-4 flex items-center justify-center gap-3">
         <SparklesIcon size={32} class="text-primary" />
         <h1 class="text-3xl font-bold">Generate Summary</h1>
       </div>
-      <p class="text-base-content/70">
-        Create an AI-generated summary of your journal entries for a specific time period
-      </p>
+      <p class="text-base-content/70">Create an AI-generated summary of your journal entries for a specific time period</p>
     </div>
 
     <!-- Form -->
@@ -152,26 +140,14 @@
         <form on:submit|preventDefault={generateSummary} class="space-y-6">
           <!-- Period Selection -->
           <div class="form-control">
-            <span class="label-text font-medium mb-2 block">Summary Period</span>
+            <span class="label-text mb-2 block font-medium">Summary Period</span>
             <div class="flex gap-4">
               <label class="label cursor-pointer">
-                <input 
-                  type="radio" 
-                  bind:group={formData.period} 
-                  value="week"
-                  on:change={handlePeriodChange}
-                  class="radio radio-primary" 
-                />
+                <input type="radio" bind:group={formData.period} value="week" on:change={handlePeriodChange} class="radio radio-primary" />
                 <span class="label-text ml-2">Weekly</span>
               </label>
               <label class="label cursor-pointer">
-                <input 
-                  type="radio" 
-                  bind:group={formData.period} 
-                  value="month"
-                  on:change={handlePeriodChange}
-                  class="radio radio-secondary" 
-                />
+                <input type="radio" bind:group={formData.period} value="month" on:change={handlePeriodChange} class="radio radio-secondary" />
                 <span class="label-text ml-2">Monthly</span>
               </label>
             </div>
@@ -192,25 +168,13 @@
               <label for="start-date" class="label">
                 <span class="label-text">Start Date</span>
               </label>
-              <input 
-                id="start-date"
-                type="date" 
-                bind:value={formData.startDate}
-                class="input input-bordered"
-                required 
-              />
+              <input id="start-date" type="date" bind:value={formData.startDate} class="input input-bordered" required />
             </div>
             <div class="form-control">
               <label for="end-date" class="label">
                 <span class="label-text">End Date</span>
               </label>
-              <input 
-                id="end-date"
-                type="date" 
-                bind:value={formData.endDate}
-                class="input input-bordered"
-                required 
-              />
+              <input id="end-date" type="date" bind:value={formData.endDate} class="input input-bordered" required />
             </div>
           </div>
 
@@ -218,18 +182,10 @@
           <div class="form-control">
             <span class="label-text mb-2 block">Quick Presets</span>
             <div class="flex flex-wrap gap-2">
-              <button 
-                type="button" 
-                on:click={setCurrentPeriod}
-                class="btn btn-outline btn-sm"
-              >
+              <button type="button" on:click={setCurrentPeriod} class="btn btn-outline btn-sm">
                 Current {formData.period === 'week' ? 'Week' : 'Month'}
               </button>
-              <button 
-                type="button" 
-                on:click={setPreviousPeriod}
-                class="btn btn-outline btn-sm"
-              >
+              <button type="button" on:click={setPreviousPeriod} class="btn btn-outline btn-sm">
                 Previous {formData.period === 'week' ? 'Week' : 'Month'}
               </button>
             </div>
@@ -248,19 +204,15 @@
             <div>
               <h4 class="font-medium">How it works</h4>
               <p class="text-sm opacity-75">
-                We'll analyze all your completed journal entries from the selected period and create a cohesive summary 
-                highlighting key themes, patterns, and insights.
+                We'll analyze all your completed journal entries from the selected period and create a cohesive summary highlighting key themes, patterns, and
+                insights.
               </p>
             </div>
           </div>
 
           <!-- Actions -->
           <div class="flex flex-col gap-3 sm:flex-row-reverse">
-            <button 
-              type="submit" 
-              disabled={!isFormValid} 
-              class="btn btn-primary gap-2 flex-1 sm:flex-none"
-            >
+            <button type="submit" disabled={!isFormValid} class="btn btn-primary flex-1 gap-2 sm:flex-none">
               {#if generating}
                 <span class="loading loading-spinner loading-sm"></span>
                 Generating...
@@ -269,12 +221,7 @@
                 Generate Summary
               {/if}
             </button>
-            <button 
-              type="button" 
-              on:click={goBack} 
-              class="btn btn-outline flex-1 sm:flex-none"
-              disabled={generating}
-            >
+            <button type="button" on:click={goBack} class="btn btn-outline flex-1 sm:flex-none" disabled={generating}>
               <ArrowLeftIcon size={16} />
               Cancel
             </button>
@@ -285,8 +232,8 @@
 
     <!-- Additional Info -->
     <div class="mt-8 text-center">
-      <div class="text-sm text-base-content/60">
-        <ClockIcon size={14} class="inline mr-1" />
+      <div class="text-base-content/60 text-sm">
+        <ClockIcon size={14} class="mr-1 inline" />
         Summary generation typically takes 10-30 seconds
       </div>
     </div>

--- a/tests/e2e/journal-summaries.spec.ts
+++ b/tests/e2e/journal-summaries.spec.ts
@@ -1,0 +1,520 @@
+import { test, expect } from '@playwright/test';
+import { loginUser } from './test-helpers';
+
+test.describe('Journal Summaries Feature', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginUser(page);
+    await page.waitForLoadState('networkidle');
+  });
+
+  async function cleanupJournalSummaries(page: any) {
+    try {
+      const authToken = (await page.evaluate('localStorage.getItem("token")')) || '';
+      
+      // Get all summaries to delete
+      const response = await page.request.get('/api/journal-summaries', {
+        headers: {
+          Authorization: `Bearer ${authToken}`,
+        },
+      });
+      
+      if (response.ok()) {
+        const data = await response.json();
+        if (data.success && data.data.summaries.length > 0) {
+          // Delete each summary
+          for (const summary of data.data.summaries) {
+            await page.request.delete(`/api/journal-summaries/${summary.id}`, {
+              headers: {
+                Authorization: `Bearer ${authToken}`,
+              },
+            });
+          }
+        }
+      }
+    } catch (error) {
+      // Ignore errors - summaries might not exist
+    }
+  }
+
+  async function createTestJournals(page: any) {
+    const authToken = (await page.evaluate('localStorage.getItem("token")')) || '';
+    
+    // Create some test journal entries for the past week
+    const testJournals = [
+      {
+        date: '2024-01-15',
+        initialMessage: 'Had a productive day working on the journal app. Made significant progress on the backend API.',
+      },
+      {
+        date: '2024-01-16', 
+        initialMessage: 'Focused on frontend development today. Created new components and improved the UI.',
+      },
+      {
+        date: '2024-01-17',
+        initialMessage: 'Debugging session day. Fixed several complex issues and learned a lot about async handling.',
+      },
+    ];
+
+    for (const journal of testJournals) {
+      try {
+        // First create the journal
+        const createRes = await page.request.post('/api/journals', {
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${authToken}`,
+          },
+          data: journal,
+        });
+
+        if (createRes.ok()) {
+          const journalData = await createRes.json();
+          const journalId = journalData.data.id;
+
+          // Complete the journal to make it available for summaries
+          await page.request.put(`/api/journals/${journalId}/complete`, {
+            headers: {
+              'Content-Type': 'application/json',
+              Authorization: `Bearer ${authToken}`,
+            },
+            data: {
+              summary: journal.initialMessage,
+              dayRating: 4,
+            },
+          });
+        }
+      } catch (error) {
+        // Journal might already exist, continue
+      }
+    }
+  }
+
+  test.afterEach(async ({ page }) => {
+    await cleanupJournalSummaries(page);
+  });
+
+  test('should navigate to journal summaries page', async ({ page }) => {
+    await page.goto('/journal-summaries');
+    await expect(page).toHaveURL('/journal-summaries');
+    await expect(page.locator('h1')).toContainText('Journal Summaries');
+  });
+
+  test('should display empty state when no summaries exist', async ({ page }) => {
+    await cleanupJournalSummaries(page);
+    await page.goto('/journal-summaries');
+    
+    await expect(page.locator('text=No Journal Summaries Yet')).toBeVisible();
+    await expect(page.locator('text=Create your first journal summary')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Create Weekly Summary' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Create Monthly Summary' })).toBeVisible();
+  });
+
+  test('should show generate summary page', async ({ page }) => {
+    await page.goto('/journal-summaries/generate');
+    
+    await expect(page).toHaveURL('/journal-summaries/generate');
+    await expect(page.locator('h1')).toContainText('Generate Summary');
+    await expect(page.locator('text=Create an AI-generated summary')).toBeVisible();
+    
+    // Check form elements are present
+    await expect(page.locator('input[type="radio"][value="week"]')).toBeVisible();
+    await expect(page.locator('input[type="radio"][value="month"]')).toBeVisible();
+    await expect(page.locator('input#start-date')).toBeVisible();
+    await expect(page.locator('input#end-date')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Generate Summary' })).toBeVisible();
+  });
+
+  test('should generate a weekly summary', async ({ page }) => {
+    await cleanupJournalSummaries(page);
+    await createTestJournals(page);
+    
+    await page.goto('/journal-summaries/generate');
+    
+    // Select weekly period (should be default)
+    await page.check('input[type="radio"][value="week"]');
+    
+    // Set date range for the week containing our test journals
+    await page.fill('input#start-date', '2024-01-15');
+    await page.fill('input#end-date', '2024-01-21');
+    
+    // Generate summary
+    await page.click('button[type="submit"]');
+    
+    // Wait for generation to complete (this might take some time with GPT)
+    await expect(page.locator('text=Generating')).toBeVisible();
+    
+    // Should either navigate to summary detail page or show an error
+    // (GPT might not be available in test environment)
+    await page.waitForLoadState('networkidle', { timeout: 30000 });
+    
+    // Check if we're on a summary detail page or if there's an error
+    const currentUrl = page.url();
+    if (currentUrl.includes('/journal-summaries/') && !currentUrl.includes('/generate')) {
+      // Successfully generated and navigated to detail page
+      await expect(page.locator('h1')).toContainText('Summary');
+    } else {
+      // Might have failed due to GPT not being available
+      // That's okay in the test environment
+    }
+  });
+
+  test('should display summary list with filtering', async ({ page }) => {
+    await cleanupJournalSummaries(page);
+    
+    // Create a test summary via API
+    const authToken = (await page.evaluate('localStorage.getItem("token")')) || '';
+    await page.request.post('/api/journal-summaries', {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${authToken}`,
+      },
+      data: {
+        period: 'week',
+        startDate: '2024-01-15',
+        endDate: '2024-01-21',
+        summary: 'Test weekly summary content',
+        tags: ['productivity', 'coding'],
+      },
+    });
+    
+    await page.goto('/journal-summaries');
+    
+    // Check summary card is displayed
+    await expect(page.locator('.card').first()).toBeVisible();
+    await expect(page.locator('text=Test weekly summary content')).toBeVisible();
+    await expect(page.locator('text=productivity')).toBeVisible();
+    await expect(page.locator('text=coding')).toBeVisible();
+    
+    // Test filtering by period
+    await page.selectOption('select:near(:text("Period"))', 'week');
+    await expect(page.locator('.card')).toHaveCount(1);
+    
+    // Test filtering by monthly (should show no results)
+    await page.selectOption('select:near(:text("Period"))', 'month');
+    await expect(page.locator('text=No Journal Summaries Yet')).toBeVisible();
+  });
+
+  test('should view summary details', async ({ page }) => {
+    await cleanupJournalSummaries(page);
+    
+    // Create a test summary via API
+    const authToken = (await page.evaluate('localStorage.getItem("token")')) || '';
+    const response = await page.request.post('/api/journal-summaries', {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${authToken}`,
+      },
+      data: {
+        period: 'week',
+        startDate: '2024-01-15',
+        endDate: '2024-01-21',
+        summary: 'This week was focused on development work with significant progress made.',
+        tags: ['development', 'progress'],
+      },
+    });
+    
+    const data = await response.json();
+    const summaryId = data.data.id;
+    
+    await page.goto(`/journal-summaries/${summaryId}`);
+    
+    // Check summary details are displayed
+    await expect(page.locator('text=This week was focused on development')).toBeVisible();
+    await expect(page.locator('text=development')).toBeVisible();
+    await expect(page.locator('text=progress')).toBeVisible();
+    
+    // Check action buttons are present
+    await expect(page.getByRole('button', { name: 'Edit' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Delete' })).toBeVisible();
+  });
+
+  test('should edit summary successfully', async ({ page }) => {
+    await cleanupJournalSummaries(page);
+    
+    // Create a test summary via API
+    const authToken = (await page.evaluate('localStorage.getItem("token")')) || '';
+    const response = await page.request.post('/api/journal-summaries', {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${authToken}`,
+      },
+      data: {
+        period: 'week',
+        startDate: '2024-01-15',
+        endDate: '2024-01-21',
+        summary: 'Original summary content',
+        tags: ['original'],
+      },
+    });
+    
+    const data = await response.json();
+    const summaryId = data.data.id;
+    
+    await page.goto(`/journal-summaries/${summaryId}`);
+    
+    // Click edit button
+    await page.click('button:has-text("Edit")');
+    
+    // Should show edit form
+    await expect(page.locator('textarea#summary-content')).toBeVisible();
+    await expect(page.locator('input#tags-input')).toBeVisible();
+    
+    // Update the summary
+    await page.fill('textarea#summary-content', 'Updated summary content with new insights');
+    await page.fill('input#tags-input', 'updated, insights, development');
+    
+    // Save changes
+    await page.click('button[type="submit"]');
+    
+    // Should show updated content
+    await expect(page.locator('text=Updated summary content with new insights')).toBeVisible();
+    await expect(page.locator('text=updated')).toBeVisible();
+    await expect(page.locator('text=insights')).toBeVisible();
+    await expect(page.locator('text=development')).toBeVisible();
+  });
+
+  test('should delete summary with confirmation', async ({ page }) => {
+    await cleanupJournalSummaries(page);
+    
+    // Create a test summary via API
+    const authToken = (await page.evaluate('localStorage.getItem("token")')) || '';
+    const response = await page.request.post('/api/journal-summaries', {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${authToken}`,
+      },
+      data: {
+        period: 'week',
+        startDate: '2024-01-15',
+        endDate: '2024-01-21',
+        summary: 'Summary to be deleted',
+        tags: ['delete-test'],
+      },
+    });
+    
+    const data = await response.json();
+    const summaryId = data.data.id;
+    
+    await page.goto(`/journal-summaries/${summaryId}`);
+    
+    // Click delete button
+    await page.click('button:has-text("Delete")');
+    
+    // Should show confirmation dialog
+    await expect(page.locator('text=Are you sure you want to delete this summary?')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Delete Permanently' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Cancel' })).toBeVisible();
+    
+    // Confirm deletion
+    await page.click('button:has-text("Delete Permanently")');
+    
+    // Should redirect to summaries list
+    await expect(page).toHaveURL('/journal-summaries');
+  });
+
+  test('should cancel delete operation', async ({ page }) => {
+    await cleanupJournalSummaries(page);
+    
+    // Create a test summary via API
+    const authToken = (await page.evaluate('localStorage.getItem("token")')) || '';
+    const response = await page.request.post('/api/journal-summaries', {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${authToken}`,
+      },
+      data: {
+        period: 'week',
+        startDate: '2024-01-15',
+        endDate: '2024-01-21',
+        summary: 'Summary not to be deleted',
+        tags: ['keep-test'],
+      },
+    });
+    
+    const data = await response.json();
+    const summaryId = data.data.id;
+    
+    await page.goto(`/journal-summaries/${summaryId}`);
+    
+    // Click delete button
+    await page.click('button:has-text("Delete")');
+    
+    // Should show confirmation dialog
+    await expect(page.locator('text=Are you sure you want to delete this summary?')).toBeVisible();
+    
+    // Cancel deletion
+    await page.click('button:has-text("Cancel")');
+    
+    // Should stay on summary page and summary should still exist
+    await expect(page).toHaveURL(`/journal-summaries/${summaryId}`);
+    await expect(page.locator('text=Summary not to be deleted')).toBeVisible();
+  });
+
+  test('should handle date range presets', async ({ page }) => {
+    await page.goto('/journal-summaries/generate');
+    
+    // Test "Current Week" preset
+    await page.click('button:has-text("Current Week")');
+    
+    const startDateValue = await page.inputValue('input#start-date');
+    const endDateValue = await page.inputValue('input#end-date');
+    
+    // Should set date range to current week
+    expect(startDateValue).toBeTruthy();
+    expect(endDateValue).toBeTruthy();
+    expect(new Date(endDateValue).getTime()).toBeGreaterThan(new Date(startDateValue).getTime());
+    
+    // Test "Previous Week" preset
+    await page.click('button:has-text("Previous Week")');
+    
+    const lastWeekStart = await page.inputValue('input#start-date');
+    const lastWeekEnd = await page.inputValue('input#end-date');
+    
+    expect(lastWeekStart).toBeTruthy();
+    expect(lastWeekEnd).toBeTruthy();
+    expect(new Date(lastWeekStart).getTime()).toBeLessThan(new Date(startDateValue).getTime());
+  });
+
+  test('should validate form inputs', async ({ page }) => {
+    await page.goto('/journal-summaries/generate');
+    
+    // Clear the date inputs
+    await page.fill('input#start-date', '');
+    await page.fill('input#end-date', '');
+    
+    // Try to submit without dates
+    await page.click('button[type="submit"]');
+    
+    // Should not proceed (browser validation will prevent submission)
+    await expect(page).toHaveURL('/journal-summaries/generate');
+  });
+
+  test('should navigate between summary pages via links', async ({ page }) => {
+    await page.goto('/journal-summaries');
+    
+    // Test navigation to generate page
+    await page.click('button:has-text("Weekly Summary")');
+    await expect(page).toHaveURL(/\/journal-summaries\/generate/);
+    
+    // Test back to list
+    await page.click('button:has-text("Journal Summaries")');
+    await expect(page).toHaveURL('/journal-summaries');
+  });
+
+  test('should handle API errors gracefully', async ({ page }) => {
+    await page.goto('/journal-summaries/generate');
+    
+    // Fill valid form data
+    await page.check('input[type="radio"][value="week"]');
+    await page.fill('input#start-date', '2024-01-15');
+    await page.fill('input#end-date', '2024-01-21');
+    
+    // Mock API failure by intercepting the request
+    await page.route('/api/journal-summaries/generate', (route) => {
+      route.fulfill({
+        status: 500,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: false,
+          error: 'Internal server error',
+        }),
+      });
+    });
+    
+    // Submit form
+    await page.click('button[type="submit"]');
+    
+    // Should show error message
+    await expect(page.locator('text=Internal server error')).toBeVisible();
+  });
+
+  test('should display correct period badges and formatting', async ({ page }) => {
+    await cleanupJournalSummaries(page);
+    
+    // Create test summaries with different periods
+    const authToken = (await page.evaluate('localStorage.getItem("token")')) || '';
+    
+    const summaries = [
+      {
+        period: 'week',
+        startDate: '2024-01-15',
+        endDate: '2024-01-21',
+        summary: 'Weekly summary',
+        tags: ['weekly'],
+      },
+      {
+        period: 'month',
+        startDate: '2024-01-01',
+        endDate: '2024-01-31',
+        summary: 'Monthly summary',
+        tags: ['monthly'],
+      },
+    ];
+    
+    for (const summary of summaries) {
+      await page.request.post('/api/journal-summaries', {
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${authToken}`,
+        },
+        data: summary,
+      });
+    }
+    
+    await page.goto('/journal-summaries');
+    
+    // Should show both summaries with correct badges
+    await expect(page.locator('.badge:has-text("week")')).toBeVisible();
+    await expect(page.locator('.badge:has-text("month")')).toBeVisible();
+    
+    // Check date formatting
+    await expect(page.locator('text=Jan 15 - Jan 21')).toBeVisible();
+    await expect(page.locator('text=January 2024')).toBeVisible();
+  });
+
+  test('should filter summaries by year', async ({ page }) => {
+    await cleanupJournalSummaries(page);
+    
+    // Create test summaries for different years
+    const authToken = (await page.evaluate('localStorage.getItem("token")')) || '';
+    
+    const summaries = [
+      {
+        period: 'week',
+        startDate: '2024-01-15',
+        endDate: '2024-01-21',
+        summary: '2024 summary',
+        tags: ['2024'],
+      },
+      {
+        period: 'week',
+        startDate: '2023-12-25',
+        endDate: '2023-12-31',
+        summary: '2023 summary',
+        tags: ['2023'],
+      },
+    ];
+    
+    for (const summary of summaries) {
+      await page.request.post('/api/journal-summaries', {
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${authToken}`,
+        },
+        data: summary,
+      });
+    }
+    
+    await page.goto('/journal-summaries');
+    
+    // Should show both summaries initially
+    await expect(page.locator('text=2024 summary')).toBeVisible();
+    await expect(page.locator('text=2023 summary')).toBeVisible();
+    
+    // Filter by 2024
+    await page.selectOption('select:near(:text("Year"))', '2024');
+    
+    // Should only show 2024 summary
+    await expect(page.locator('text=2024 summary')).toBeVisible();
+    await expect(page.locator('text=2023 summary')).not.toBeVisible();
+  });
+});

--- a/tests/e2e/journal-summaries.spec.ts
+++ b/tests/e2e/journal-summaries.spec.ts
@@ -10,14 +10,14 @@ test.describe('Journal Summaries Feature', () => {
   async function cleanupJournalSummaries(page: any) {
     try {
       const authToken = (await page.evaluate('localStorage.getItem("token")')) || '';
-      
+
       // Get all summaries to delete
       const response = await page.request.get('/api/journal-summaries', {
         headers: {
           Authorization: `Bearer ${authToken}`,
         },
       });
-      
+
       if (response.ok()) {
         const data = await response.json();
         if (data.success && data.data.summaries.length > 0) {
@@ -38,7 +38,7 @@ test.describe('Journal Summaries Feature', () => {
 
   async function createTestJournals(page: any) {
     const authToken = (await page.evaluate('localStorage.getItem("token")')) || '';
-    
+
     // Create some test journal entries for the past week
     const testJournals = [
       {
@@ -46,7 +46,7 @@ test.describe('Journal Summaries Feature', () => {
         initialMessage: 'Had a productive day working on the journal app. Made significant progress on the backend API.',
       },
       {
-        date: '2024-01-16', 
+        date: '2024-01-16',
         initialMessage: 'Focused on frontend development today. Created new components and improved the UI.',
       },
       {
@@ -101,7 +101,7 @@ test.describe('Journal Summaries Feature', () => {
   test('should display empty state when no summaries exist', async ({ page }) => {
     await cleanupJournalSummaries(page);
     await page.goto('/journal-summaries');
-    
+
     await expect(page.locator('text=No Journal Summaries Yet')).toBeVisible();
     await expect(page.locator('text=Create your first journal summary')).toBeVisible();
     await expect(page.getByRole('button', { name: 'Create Weekly Summary' })).toBeVisible();
@@ -110,11 +110,11 @@ test.describe('Journal Summaries Feature', () => {
 
   test('should show generate summary page', async ({ page }) => {
     await page.goto('/journal-summaries/generate');
-    
+
     await expect(page).toHaveURL('/journal-summaries/generate');
     await expect(page.locator('h1')).toContainText('Generate Summary');
     await expect(page.locator('text=Create an AI-generated summary')).toBeVisible();
-    
+
     // Check form elements are present
     await expect(page.locator('input[type="radio"][value="week"]')).toBeVisible();
     await expect(page.locator('input[type="radio"][value="month"]')).toBeVisible();
@@ -126,26 +126,26 @@ test.describe('Journal Summaries Feature', () => {
   test('should generate a weekly summary', async ({ page }) => {
     await cleanupJournalSummaries(page);
     await createTestJournals(page);
-    
+
     await page.goto('/journal-summaries/generate');
-    
+
     // Select weekly period (should be default)
     await page.check('input[type="radio"][value="week"]');
-    
+
     // Set date range for the week containing our test journals
     await page.fill('input#start-date', '2024-01-15');
     await page.fill('input#end-date', '2024-01-21');
-    
+
     // Generate summary
     await page.click('button[type="submit"]');
-    
+
     // Wait for generation to complete (this might take some time with GPT)
     await expect(page.locator('text=Generating')).toBeVisible();
-    
+
     // Should either navigate to summary detail page or show an error
     // (GPT might not be available in test environment)
     await page.waitForLoadState('networkidle', { timeout: 30000 });
-    
+
     // Check if we're on a summary detail page or if there's an error
     const currentUrl = page.url();
     if (currentUrl.includes('/journal-summaries/') && !currentUrl.includes('/generate')) {
@@ -159,7 +159,7 @@ test.describe('Journal Summaries Feature', () => {
 
   test('should display summary list with filtering', async ({ page }) => {
     await cleanupJournalSummaries(page);
-    
+
     // Create a test summary via API
     const authToken = (await page.evaluate('localStorage.getItem("token")')) || '';
     await page.request.post('/api/journal-summaries', {
@@ -175,19 +175,19 @@ test.describe('Journal Summaries Feature', () => {
         tags: ['productivity', 'coding'],
       },
     });
-    
+
     await page.goto('/journal-summaries');
-    
+
     // Check summary card is displayed
     await expect(page.locator('.card').first()).toBeVisible();
     await expect(page.locator('text=Test weekly summary content')).toBeVisible();
     await expect(page.locator('text=productivity')).toBeVisible();
     await expect(page.locator('text=coding')).toBeVisible();
-    
+
     // Test filtering by period
     await page.selectOption('select:near(:text("Period"))', 'week');
     await expect(page.locator('.card')).toHaveCount(1);
-    
+
     // Test filtering by monthly (should show no results)
     await page.selectOption('select:near(:text("Period"))', 'month');
     await expect(page.locator('text=No Journal Summaries Yet')).toBeVisible();
@@ -195,7 +195,7 @@ test.describe('Journal Summaries Feature', () => {
 
   test('should view summary details', async ({ page }) => {
     await cleanupJournalSummaries(page);
-    
+
     // Create a test summary via API
     const authToken = (await page.evaluate('localStorage.getItem("token")')) || '';
     const response = await page.request.post('/api/journal-summaries', {
@@ -211,17 +211,17 @@ test.describe('Journal Summaries Feature', () => {
         tags: ['development', 'progress'],
       },
     });
-    
+
     const data = await response.json();
     const summaryId = data.data.id;
-    
+
     await page.goto(`/journal-summaries/${summaryId}`);
-    
+
     // Check summary details are displayed
     await expect(page.locator('text=This week was focused on development')).toBeVisible();
     await expect(page.locator('text=development')).toBeVisible();
     await expect(page.locator('text=progress')).toBeVisible();
-    
+
     // Check action buttons are present
     await expect(page.getByRole('button', { name: 'Edit' })).toBeVisible();
     await expect(page.getByRole('button', { name: 'Delete' })).toBeVisible();
@@ -229,7 +229,7 @@ test.describe('Journal Summaries Feature', () => {
 
   test('should edit summary successfully', async ({ page }) => {
     await cleanupJournalSummaries(page);
-    
+
     // Create a test summary via API
     const authToken = (await page.evaluate('localStorage.getItem("token")')) || '';
     const response = await page.request.post('/api/journal-summaries', {
@@ -245,26 +245,26 @@ test.describe('Journal Summaries Feature', () => {
         tags: ['original'],
       },
     });
-    
+
     const data = await response.json();
     const summaryId = data.data.id;
-    
+
     await page.goto(`/journal-summaries/${summaryId}`);
-    
+
     // Click edit button
     await page.click('button:has-text("Edit")');
-    
+
     // Should show edit form
     await expect(page.locator('textarea#summary-content')).toBeVisible();
     await expect(page.locator('input#tags-input')).toBeVisible();
-    
+
     // Update the summary
     await page.fill('textarea#summary-content', 'Updated summary content with new insights');
     await page.fill('input#tags-input', 'updated, insights, development');
-    
+
     // Save changes
     await page.click('button[type="submit"]');
-    
+
     // Should show updated content
     await expect(page.locator('text=Updated summary content with new insights')).toBeVisible();
     await expect(page.locator('text=updated')).toBeVisible();
@@ -274,7 +274,7 @@ test.describe('Journal Summaries Feature', () => {
 
   test('should delete summary with confirmation', async ({ page }) => {
     await cleanupJournalSummaries(page);
-    
+
     // Create a test summary via API
     const authToken = (await page.evaluate('localStorage.getItem("token")')) || '';
     const response = await page.request.post('/api/journal-summaries', {
@@ -290,30 +290,30 @@ test.describe('Journal Summaries Feature', () => {
         tags: ['delete-test'],
       },
     });
-    
+
     const data = await response.json();
     const summaryId = data.data.id;
-    
+
     await page.goto(`/journal-summaries/${summaryId}`);
-    
+
     // Click delete button
     await page.click('button:has-text("Delete")');
-    
+
     // Should show confirmation dialog
     await expect(page.locator('text=Are you sure you want to delete this summary?')).toBeVisible();
     await expect(page.getByRole('button', { name: 'Delete Permanently' })).toBeVisible();
     await expect(page.getByRole('button', { name: 'Cancel' })).toBeVisible();
-    
+
     // Confirm deletion
     await page.click('button:has-text("Delete Permanently")');
-    
+
     // Should redirect to summaries list
     await expect(page).toHaveURL('/journal-summaries');
   });
 
   test('should cancel delete operation', async ({ page }) => {
     await cleanupJournalSummaries(page);
-    
+
     // Create a test summary via API
     const authToken = (await page.evaluate('localStorage.getItem("token")')) || '';
     const response = await page.request.post('/api/journal-summaries', {
@@ -329,21 +329,21 @@ test.describe('Journal Summaries Feature', () => {
         tags: ['keep-test'],
       },
     });
-    
+
     const data = await response.json();
     const summaryId = data.data.id;
-    
+
     await page.goto(`/journal-summaries/${summaryId}`);
-    
+
     // Click delete button
     await page.click('button:has-text("Delete")');
-    
+
     // Should show confirmation dialog
     await expect(page.locator('text=Are you sure you want to delete this summary?')).toBeVisible();
-    
+
     // Cancel deletion
     await page.click('button:has-text("Cancel")');
-    
+
     // Should stay on summary page and summary should still exist
     await expect(page).toHaveURL(`/journal-summaries/${summaryId}`);
     await expect(page.locator('text=Summary not to be deleted')).toBeVisible();
@@ -351,24 +351,24 @@ test.describe('Journal Summaries Feature', () => {
 
   test('should handle date range presets', async ({ page }) => {
     await page.goto('/journal-summaries/generate');
-    
+
     // Test "Current Week" preset
     await page.click('button:has-text("Current Week")');
-    
+
     const startDateValue = await page.inputValue('input#start-date');
     const endDateValue = await page.inputValue('input#end-date');
-    
+
     // Should set date range to current week
     expect(startDateValue).toBeTruthy();
     expect(endDateValue).toBeTruthy();
     expect(new Date(endDateValue).getTime()).toBeGreaterThan(new Date(startDateValue).getTime());
-    
+
     // Test "Previous Week" preset
     await page.click('button:has-text("Previous Week")');
-    
+
     const lastWeekStart = await page.inputValue('input#start-date');
     const lastWeekEnd = await page.inputValue('input#end-date');
-    
+
     expect(lastWeekStart).toBeTruthy();
     expect(lastWeekEnd).toBeTruthy();
     expect(new Date(lastWeekStart).getTime()).toBeLessThan(new Date(startDateValue).getTime());
@@ -376,25 +376,25 @@ test.describe('Journal Summaries Feature', () => {
 
   test('should validate form inputs', async ({ page }) => {
     await page.goto('/journal-summaries/generate');
-    
+
     // Clear the date inputs
     await page.fill('input#start-date', '');
     await page.fill('input#end-date', '');
-    
+
     // Try to submit without dates
     await page.click('button[type="submit"]');
-    
+
     // Should not proceed (browser validation will prevent submission)
     await expect(page).toHaveURL('/journal-summaries/generate');
   });
 
   test('should navigate between summary pages via links', async ({ page }) => {
     await page.goto('/journal-summaries');
-    
+
     // Test navigation to generate page
     await page.click('button:has-text("Weekly Summary")');
     await expect(page).toHaveURL(/\/journal-summaries\/generate/);
-    
+
     // Test back to list
     await page.click('button:has-text("Journal Summaries")');
     await expect(page).toHaveURL('/journal-summaries');
@@ -402,12 +402,12 @@ test.describe('Journal Summaries Feature', () => {
 
   test('should handle API errors gracefully', async ({ page }) => {
     await page.goto('/journal-summaries/generate');
-    
+
     // Fill valid form data
     await page.check('input[type="radio"][value="week"]');
     await page.fill('input#start-date', '2024-01-15');
     await page.fill('input#end-date', '2024-01-21');
-    
+
     // Mock API failure by intercepting the request
     await page.route('/api/journal-summaries/generate', (route) => {
       route.fulfill({
@@ -419,20 +419,20 @@ test.describe('Journal Summaries Feature', () => {
         }),
       });
     });
-    
+
     // Submit form
     await page.click('button[type="submit"]');
-    
+
     // Should show error message
     await expect(page.locator('text=Internal server error')).toBeVisible();
   });
 
   test('should display correct period badges and formatting', async ({ page }) => {
     await cleanupJournalSummaries(page);
-    
+
     // Create test summaries with different periods
     const authToken = (await page.evaluate('localStorage.getItem("token")')) || '';
-    
+
     const summaries = [
       {
         period: 'week',
@@ -449,7 +449,7 @@ test.describe('Journal Summaries Feature', () => {
         tags: ['monthly'],
       },
     ];
-    
+
     for (const summary of summaries) {
       await page.request.post('/api/journal-summaries', {
         headers: {
@@ -459,13 +459,13 @@ test.describe('Journal Summaries Feature', () => {
         data: summary,
       });
     }
-    
+
     await page.goto('/journal-summaries');
-    
+
     // Should show both summaries with correct badges
     await expect(page.locator('.badge:has-text("week")')).toBeVisible();
     await expect(page.locator('.badge:has-text("month")')).toBeVisible();
-    
+
     // Check date formatting
     await expect(page.locator('text=Jan 15 - Jan 21')).toBeVisible();
     await expect(page.locator('text=January 2024')).toBeVisible();
@@ -473,10 +473,10 @@ test.describe('Journal Summaries Feature', () => {
 
   test('should filter summaries by year', async ({ page }) => {
     await cleanupJournalSummaries(page);
-    
+
     // Create test summaries for different years
     const authToken = (await page.evaluate('localStorage.getItem("token")')) || '';
-    
+
     const summaries = [
       {
         period: 'week',
@@ -493,7 +493,7 @@ test.describe('Journal Summaries Feature', () => {
         tags: ['2023'],
       },
     ];
-    
+
     for (const summary of summaries) {
       await page.request.post('/api/journal-summaries', {
         headers: {
@@ -503,16 +503,16 @@ test.describe('Journal Summaries Feature', () => {
         data: summary,
       });
     }
-    
+
     await page.goto('/journal-summaries');
-    
+
     // Should show both summaries initially
     await expect(page.locator('text=2024 summary')).toBeVisible();
     await expect(page.locator('text=2023 summary')).toBeVisible();
-    
+
     // Filter by 2024
     await page.selectOption('select:near(:text("Year"))', '2024');
-    
+
     // Should only show 2024 summary
     await expect(page.locator('text=2024 summary')).toBeVisible();
     await expect(page.locator('text=2023 summary')).not.toBeVisible();


### PR DESCRIPTION
Introduce a new table for storing system-generated summaries of journal entries, enabling richer context for GPT interactions. Implement backend and frontend logic for creating, updating, and listing summaries, along with necessary validation schemas. Update routes to include journal summaries functionality. Fix issues related to date selection.