### PR TITLE
Support journal tone tags

### DIFF
--- a/backend/src/db/migrations/0027_ambitious_prima.sql
+++ b/backend/src/db/migrations/0027_ambitious_prima.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "journals" ADD COLUMN "tone_tags" jsonb;

--- a/backend/src/db/migrations/meta/0027_snapshot.json
+++ b/backend/src/db/migrations/meta/0027_snapshot.json
@@ -1,0 +1,1881 @@
+{
+  "id": "f5c47192-4935-41b5-ac56-7a15f3a1b2ed",
+  "prevId": "f386b739-3cae-434a-b182-45188db7e2e5",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.characters": {
+      "name": "characters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_class": {
+          "name": "character_class",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backstory": {
+          "name": "backstory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goals": {
+          "name": "goals",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "motto": {
+          "name": "motto",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "characters_user_id_users_id_fk": {
+          "name": "characters_user_id_users_id_fk",
+          "tableFrom": "characters",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.character_stat_level_titles": {
+      "name": "character_stat_level_titles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "stat_id": {
+          "name": "stat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "character_stat_level_titles_stat_id_character_stats_id_fk": {
+          "name": "character_stat_level_titles_stat_id_character_stats_id_fk",
+          "tableFrom": "character_stat_level_titles",
+          "tableTo": "character_stats",
+          "columnsFrom": [
+            "stat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.character_stats": {
+      "name": "character_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "example_activities": {
+          "name": "example_activities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "current_level": {
+          "name": "current_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "total_xp": {
+          "name": "total_xp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "character_stats_user_id_users_id_fk": {
+          "name": "character_stats_user_id_users_id_fk",
+          "tableFrom": "character_stats",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.xp_grants": {
+      "name": "xp_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "xp_amount": {
+          "name": "xp_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "xp_grants_user_id_users_id_fk": {
+          "name": "xp_grants_user_id_users_id_fk",
+          "tableFrom": "xp_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.goals": {
+      "name": "goals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "goals_user_id_users_id_fk": {
+          "name": "goals_user_id_users_id_fk",
+          "tableFrom": "goals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.family_members": {
+      "name": "family_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relationship": {
+          "name": "relationship",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birthday": {
+          "name": "birthday",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "likes": {
+          "name": "likes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dislikes": {
+          "name": "dislikes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_interaction_date": {
+          "name": "last_interaction_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection_xp": {
+          "name": "connection_xp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "connection_level": {
+          "name": "connection_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "family_members_user_id_users_id_fk": {
+          "name": "family_members_user_id_users_id_fk",
+          "tableFrom": "family_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.family_task_feedback": {
+      "name": "family_task_feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "family_member_id": {
+          "name": "family_member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_description": {
+          "name": "task_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enjoyed_it": {
+          "name": "enjoyed_it",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "xp_granted": {
+          "name": "xp_granted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "family_task_feedback_user_id_users_id_fk": {
+          "name": "family_task_feedback_user_id_users_id_fk",
+          "tableFrom": "family_task_feedback",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "family_task_feedback_family_member_id_family_members_id_fk": {
+          "name": "family_task_feedback_family_member_id_family_members_id_fk",
+          "tableFrom": "family_task_feedback",
+          "tableTo": "family_members",
+          "columnsFrom": [
+            "family_member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.goal_tags": {
+      "name": "goal_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "goal_id": {
+          "name": "goal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "goal_tags_goal_id_goals_id_fk": {
+          "name": "goal_tags_goal_id_goals_id_fk",
+          "tableFrom": "goal_tags",
+          "tableTo": "goals",
+          "columnsFrom": [
+            "goal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "goal_tags_tag_id_tags_id_fk": {
+          "name": "goal_tags_tag_id_tags_id_fk",
+          "tableFrom": "goal_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tags_user_id_users_id_fk": {
+          "name": "tags_user_id_users_id_fk",
+          "tableFrom": "tags",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_tag": {
+          "name": "unique_user_tag",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.focuses": {
+      "name": "focuses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "focuses_user_id_users_id_fk": {
+          "name": "focuses_user_id_users_id_fk",
+          "tableFrom": "focuses",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simple_todos": {
+      "name": "simple_todos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_completed": {
+          "name": "is_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiration_time": {
+          "name": "expiration_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "simple_todos_user_id_users_id_fk": {
+          "name": "simple_todos_user_id_users_id_fk",
+          "tableFrom": "simple_todos",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.experiment_task_completions": {
+      "name": "experiment_task_completions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_date": {
+          "name": "completed_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "experiment_task_completions_task_id_experiment_tasks_id_fk": {
+          "name": "experiment_task_completions_task_id_experiment_tasks_id_fk",
+          "tableFrom": "experiment_task_completions",
+          "tableTo": "experiment_tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "experiment_task_completions_user_id_users_id_fk": {
+          "name": "experiment_task_completions_user_id_users_id_fk",
+          "tableFrom": "experiment_task_completions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.experiment_tasks": {
+      "name": "experiment_tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "experiment_id": {
+          "name": "experiment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stat_id": {
+          "name": "stat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success_metric": {
+          "name": "success_metric",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "xp_reward": {
+          "name": "xp_reward",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "experiment_tasks_experiment_id_experiments_id_fk": {
+          "name": "experiment_tasks_experiment_id_experiments_id_fk",
+          "tableFrom": "experiment_tasks",
+          "tableTo": "experiments",
+          "columnsFrom": [
+            "experiment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "experiment_tasks_stat_id_character_stats_id_fk": {
+          "name": "experiment_tasks_stat_id_character_stats_id_fk",
+          "tableFrom": "experiment_tasks",
+          "tableTo": "character_stats",
+          "columnsFrom": [
+            "stat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.experiments": {
+      "name": "experiments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reflection": {
+          "name": "reflection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "should_repeat": {
+          "name": "should_repeat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "experiments_user_id_users_id_fk": {
+          "name": "experiments_user_id_users_id_fk",
+          "tableFrom": "experiments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.journals": {
+      "name": "journals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "initial_message": {
+          "name": "initial_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_session": {
+          "name": "chat_session",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synopsis": {
+          "name": "synopsis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tone_tags": {
+          "name": "tone_tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "day_rating": {
+          "name": "day_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inferred_day_rating": {
+          "name": "inferred_day_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "journals_user_id_users_id_fk": {
+          "name": "journals_user_id_users_id_fk",
+          "tableFrom": "journals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.journal_summaries": {
+      "name": "journal_summaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period": {
+          "name": "period",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "journal_summaries_user_id_users_id_fk": {
+          "name": "journal_summaries_user_id_users_id_fk",
+          "tableFrom": "journal_summaries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quest_experiments": {
+      "name": "quest_experiments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "quest_id": {
+          "name": "quest_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "experiment_id": {
+          "name": "experiment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "quest_experiments_quest_id_quests_id_fk": {
+          "name": "quest_experiments_quest_id_quests_id_fk",
+          "tableFrom": "quest_experiments",
+          "tableTo": "quests",
+          "columnsFrom": [
+            "quest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "quest_experiments_experiment_id_experiments_id_fk": {
+          "name": "quest_experiments_experiment_id_experiments_id_fk",
+          "tableFrom": "quest_experiments",
+          "tableTo": "experiments",
+          "columnsFrom": [
+            "experiment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quest_journals": {
+      "name": "quest_journals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "quest_id": {
+          "name": "quest_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "journal_id": {
+          "name": "journal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linked_type": {
+          "name": "linked_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'automatic'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "quest_journals_quest_id_quests_id_fk": {
+          "name": "quest_journals_quest_id_quests_id_fk",
+          "tableFrom": "quest_journals",
+          "tableTo": "quests",
+          "columnsFrom": [
+            "quest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "quest_journals_journal_id_journals_id_fk": {
+          "name": "quest_journals_journal_id_journals_id_fk",
+          "tableFrom": "quest_journals",
+          "tableTo": "journals",
+          "columnsFrom": [
+            "journal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quests": {
+      "name": "quests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reflection": {
+          "name": "reflection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "quests_user_id_users_id_fk": {
+          "name": "quests_user_id_users_id_fk",
+          "tableFrom": "quests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plan_subtasks": {
+      "name": "plan_subtasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_completed": {
+          "name": "is_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "plan_subtasks_plan_id_plans_id_fk": {
+          "name": "plan_subtasks_plan_id_plans_id_fk",
+          "tableFrom": "plan_subtasks",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "plan_subtasks_user_id_users_id_fk": {
+          "name": "plan_subtasks_user_id_users_id_fk",
+          "tableFrom": "plan_subtasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plans": {
+      "name": "plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focus_id": {
+          "name": "focus_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_ordered": {
+          "name": "is_ordered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "plans_user_id_users_id_fk": {
+          "name": "plans_user_id_users_id_fk",
+          "tableFrom": "plans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "plans_focus_id_focuses_id_fk": {
+          "name": "plans_focus_id_focuses_id_fk",
+          "tableFrom": "plans",
+          "tableTo": "focuses",
+          "columnsFrom": [
+            "focus_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/src/db/migrations/meta/_journal.json
+++ b/backend/src/db/migrations/meta/_journal.json
@@ -190,6 +190,13 @@
       "when": 1752957825079,
       "tag": "0026_new_impossible_man",
       "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "7",
+      "when": 1753318635006,
+      "tag": "0027_ambitious_prima",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/db/schema/journals.ts
+++ b/backend/src/db/schema/journals.ts
@@ -13,6 +13,7 @@ export const journals = pgTable('journals', {
   summary: text('summary'), // GPT-generated summary
   title: text('title'), // GPT-generated title
   synopsis: text('synopsis'), // GPT-generated synopsis
+  toneTags: jsonb('tone_tags'), // GPT-extracted emotional tone tags (max 2, constrained to fixed set)
   dayRating: integer('day_rating'), // User-provided rating of their day (1-5)
   inferredDayRating: integer('inferred_day_rating'), // AI-inferred rating of the day (1-5)
   createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),

--- a/backend/src/routes/journals.ts
+++ b/backend/src/routes/journals.ts
@@ -25,6 +25,7 @@ import type {
   ListJournalsRequest,
   ListJournalsResponse,
   JournalListItem,
+  ToneTag,
 } from '../types/journals';
 
 /**
@@ -41,6 +42,7 @@ const serializeJournal = (journal: typeof journals.$inferSelect): JournalRespons
     summary: journal.summary,
     title: journal.title,
     synopsis: journal.synopsis,
+    toneTags: journal.toneTags ? (journal.toneTags as ToneTag[]) : null,
     dayRating: journal.dayRating,
     inferredDayRating: journal.inferredDayRating,
     createdAt: journal.createdAt.toISOString(),
@@ -63,6 +65,7 @@ const serializeJournalListItem = (journal: typeof journals.$inferSelect): Journa
     title: journal.title,
     synopsis: journal.synopsis,
     initialMessage: journal.initialMessage,
+    toneTags: journal.toneTags ? (journal.toneTags as ToneTag[]) : null,
     dayRating: journal.dayRating,
     inferredDayRating: journal.inferredDayRating,
     createdAt: journal.createdAt.toISOString(),
@@ -176,6 +179,7 @@ const app = new Hono()
             summary: journals.summary,
             title: journals.title,
             synopsis: journals.synopsis,
+            toneTags: journals.toneTags,
             dayRating: journals.dayRating,
             inferredDayRating: journals.inferredDayRating,
             createdAt: journals.createdAt,
@@ -389,13 +393,16 @@ const app = new Hono()
       if (data.synopsis !== undefined) {
         updateData.synopsis = data.synopsis;
       }
+      if (data.toneTags !== undefined) {
+        updateData.toneTags = data.toneTags;
+      }
       if (data.dayRating !== undefined) {
         updateData.dayRating = data.dayRating;
       }
       if (data.inferredDayRating !== undefined) {
         updateData.inferredDayRating = data.inferredDayRating;
       }
-      // Note: toneTags, contentTags, and statTags are deprecated - now using xpGrants table
+      // Note: toneTags are now supported as GPT-extracted emotional tags
 
       const updatedJournal = await db
         .update(journals)
@@ -688,6 +695,17 @@ const app = new Hono()
       }
 
       // Update journal with metadata and summary
+      // Validate and normalize tone tags
+      const VALID_TONE_TAGS = ['happy', 'calm', 'energized', 'overwhelmed', 'sad', 'angry', 'anxious'];
+      const validatedToneTags: string[] = [];
+      if (metadata.toneTags && Array.isArray(metadata.toneTags)) {
+        for (const tag of metadata.toneTags) {
+          if (typeof tag === 'string' && VALID_TONE_TAGS.includes(tag.toLowerCase())) {
+            validatedToneTags.push(tag.toLowerCase());
+          }
+        }
+      }
+
       const updatedJournal = await db
         .update(journals)
         .set({
@@ -695,6 +713,7 @@ const app = new Hono()
           summary: summary,
           title: metadata.title,
           synopsis: metadata.synopsis,
+          toneTags: validatedToneTags,
           inferredDayRating: inferredDayRating,
           updatedAt: new Date(),
         })

--- a/backend/src/tests/journal-tone-tags.test.ts
+++ b/backend/src/tests/journal-tone-tags.test.ts
@@ -1,0 +1,356 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import appExport from '../index';
+import { testDb, getUniqueEmail, schema } from './setup';
+import { eq, and } from 'drizzle-orm';
+
+// Import the module we want to mock
+import * as gptModule from '../utils/gpt/conversationalJournal';
+
+// Create wrapper to maintain compatibility with test expectations
+const app = {
+  request: (url: string, init?: RequestInit) => {
+    const absoluteUrl = url.startsWith('http') ? url : `http://localhost${url}`;
+    return appExport.fetch(new Request(absoluteUrl, init));
+  },
+};
+
+const { journals } = schema;
+
+describe('Journal Tone Tags Integration', () => {
+  let userId: string;
+  let authToken: string;
+  let mockGenerateJournalMetadata: any;
+
+  beforeEach(async () => {
+    // Set up the mock for generateJournalMetadata
+    mockGenerateJournalMetadata = vi.spyOn(gptModule, 'generateJournalMetadata');
+
+    // Create test user and get auth token
+    const testUser = {
+      name: 'Test User',
+      email: getUniqueEmail('journal-tone'),
+      password: 'password123',
+    };
+
+    const registerResponse = await app.request('/api/users', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(testUser),
+    });
+
+    expect(registerResponse.status).toBe(201);
+    const registerData = await registerResponse.json();
+    authToken = registerData.token;
+    userId = registerData.user.id;
+  });
+
+  afterEach(async () => {
+    // Clean up test data
+    await testDb().delete(journals).where(eq(journals.userId, userId));
+  });
+
+  describe('Tone Tags Extraction on Journal Completion', () => {
+    it('should extract and store tone tags when journal is finished', async () => {
+      // Mock the GPT response to return tone tags
+      (mockGenerateJournalMetadata as any).mockResolvedValue({
+        title: 'A Joyful and Energetic Day',
+        synopsis: 'User experienced happiness and high energy throughout the day',
+        summary: 'Today was filled with positive emotions and good energy',
+        suggestedTags: [],
+        suggestedStatTags: {},
+        suggestedFamilyTags: {},
+        toneTags: ['happy', 'energized'],
+        suggestedTodos: [],
+      });
+
+      const date = '2024-01-15';
+
+      // Create journal in review state
+      await testDb()
+        .insert(journals)
+        .values({
+          userId,
+          date,
+          status: 'in_review',
+          initialMessage: 'Today I felt really happy and energetic!',
+          chatSession: [
+            { role: 'user', content: 'Today I felt really happy and energetic!' },
+            { role: 'assistant', content: 'That sounds wonderful! Can you tell me more about what made you feel so positive?' },
+          ],
+        });
+
+      // Finish the journal (this will trigger GPT analysis and tone tag extraction)
+      const response = await app.request(`/api/journals/${date}/finish`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${authToken}`,
+        },
+        body: JSON.stringify({}),
+      });
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.success).toBe(true);
+      expect(data.data.status).toBe('complete');
+
+      // Verify that tone tags were extracted and stored
+      expect(data.data.toneTags).toEqual(['happy', 'energized']);
+
+      // Verify in database
+      const journalInDb = await testDb()
+        .select()
+        .from(journals)
+        .where(and(eq(journals.userId, userId), eq(journals.date, date)))
+        .limit(1);
+
+      expect(journalInDb.length).toBe(1);
+      expect(journalInDb[0].toneTags).toEqual(['happy', 'energized']);
+      expect(journalInDb[0].status).toBe('complete');
+    });
+
+    it('should store all tone tags returned by GPT', async () => {
+      // Mock the GPT response to return multiple tone tags
+      (mockGenerateJournalMetadata as any).mockResolvedValue({
+        title: 'Complex Emotional Day',
+        synopsis: 'User experienced multiple emotions',
+        summary: 'A day with many different feelings',
+        suggestedTags: [],
+        suggestedStatTags: {},
+        suggestedFamilyTags: {},
+        toneTags: ['happy', 'anxious', 'overwhelmed', 'calm'], // Multiple tags
+        suggestedTodos: [],
+      });
+
+      const date = '2024-01-16';
+
+      // Create journal in review state
+      await testDb()
+        .insert(journals)
+        .values({
+          userId,
+          date,
+          status: 'in_review',
+          initialMessage: 'Today I had so many different emotions...',
+          chatSession: [
+            { role: 'user', content: 'Today I had so many different emotions...' },
+            { role: 'assistant', content: 'That sounds like it was quite a day. Tell me more about what you experienced.' },
+          ],
+        });
+
+      // Finish the journal
+      const response = await app.request(`/api/journals/${date}/finish`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${authToken}`,
+        },
+        body: JSON.stringify({}),
+      });
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.success).toBe(true);
+
+      // Should include all valid tone tags
+      expect(data.data.toneTags).toEqual(['happy', 'anxious', 'overwhelmed', 'calm']);
+    });
+
+    it('should filter out invalid tone tags and only keep valid ones', async () => {
+      // Mock the GPT response to return some invalid tone tags
+      (mockGenerateJournalMetadata as any).mockResolvedValue({
+        title: 'Mixed Day',
+        synopsis: 'User had various feelings',
+        summary: 'A day with mixed emotions',
+        suggestedTags: [],
+        suggestedStatTags: {},
+        suggestedFamilyTags: {},
+        toneTags: ['happy', 'invalid_tag', 'excited', 'sad'], // Contains invalid tag
+        suggestedTodos: [],
+      });
+
+      const date = '2024-01-17';
+
+      // Create journal in review state
+      await testDb()
+        .insert(journals)
+        .values({
+          userId,
+          date,
+          status: 'in_review',
+          initialMessage: 'Mixed feelings today...',
+          chatSession: [
+            { role: 'user', content: 'Mixed feelings today...' },
+            { role: 'assistant', content: 'I can hear that in your message. What kind of mixed feelings?' },
+          ],
+        });
+
+      // Finish the journal
+      const response = await app.request(`/api/journals/${date}/finish`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${authToken}`,
+        },
+        body: JSON.stringify({}),
+      });
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.success).toBe(true);
+
+      // Should only include valid tone tags, and filter out 'invalid_tag' and 'excited' (not in allowed list)
+      // Should keep 'happy' and 'sad' (both are valid)
+      expect(data.data.toneTags).toEqual(['happy', 'sad']);
+    });
+
+    it('should handle empty tone tags gracefully', async () => {
+      // Mock the GPT response to return no tone tags
+      (mockGenerateJournalMetadata as any).mockResolvedValue({
+        title: 'Neutral Day',
+        synopsis: 'User had a neutral day',
+        summary: 'A regular day without strong emotions',
+        suggestedTags: [],
+        suggestedStatTags: {},
+        suggestedFamilyTags: {},
+        toneTags: [], // No tone tags
+        suggestedTodos: [],
+      });
+
+      const date = '2024-01-18';
+
+      // Create journal in review state
+      await testDb()
+        .insert(journals)
+        .values({
+          userId,
+          date,
+          status: 'in_review',
+          initialMessage: 'Just a regular day today.',
+          chatSession: [
+            { role: 'user', content: 'Just a regular day today.' },
+            { role: 'assistant', content: 'Sometimes regular days can be quite nice too. How are you feeling about that?' },
+          ],
+        });
+
+      // Finish the journal
+      const response = await app.request(`/api/journals/${date}/finish`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${authToken}`,
+        },
+        body: JSON.stringify({}),
+      });
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.success).toBe(true);
+
+      // Should have empty tone tags array
+      expect(data.data.toneTags).toEqual([]);
+    });
+
+    it('should handle case-insensitive tone tags and normalize to lowercase', async () => {
+      // Mock the GPT response to return tone tags with different cases
+      (mockGenerateJournalMetadata as any).mockResolvedValue({
+        title: 'Happy Day',
+        synopsis: 'User was happy',
+        summary: 'A happy day',
+        suggestedTags: [],
+        suggestedStatTags: {},
+        suggestedFamilyTags: {},
+        toneTags: ['HAPPY', 'Calm'], // Mixed case
+        suggestedTodos: [],
+      });
+
+      const date = '2024-01-19';
+
+      // Create journal in review state
+      await testDb()
+        .insert(journals)
+        .values({
+          userId,
+          date,
+          status: 'in_review',
+          initialMessage: 'Feeling really happy and calm today!',
+          chatSession: [
+            { role: 'user', content: 'Feeling really happy and calm today!' },
+            { role: 'assistant', content: 'That\'s wonderful to hear! What contributed to those positive feelings?' },
+          ],
+        });
+
+      // Finish the journal
+      const response = await app.request(`/api/journals/${date}/finish`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${authToken}`,
+        },
+        body: JSON.stringify({}),
+      });
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.success).toBe(true);
+
+      // Should normalize to lowercase
+      expect(data.data.toneTags).toEqual(['happy', 'calm']);
+    });
+  });
+
+  describe('Tone Tags in Journal Responses', () => {
+    it('should include tone tags in journal list responses', async () => {
+      // Create a completed journal with tone tags
+      await testDb()
+        .insert(journals)
+        .values({
+          userId,
+          date: '2024-01-20',
+          status: 'complete',
+          initialMessage: 'Happy day!',
+          title: 'Happy Day',
+          synopsis: 'A joyful day',
+          toneTags: ['happy', 'energized'],
+        });
+
+      // Get journal list
+      const response = await app.request('/api/journals', {
+        headers: { Authorization: `Bearer ${authToken}` },
+      });
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.success).toBe(true);
+      expect(data.data.journals).toHaveLength(1);
+      expect(data.data.journals[0].toneTags).toEqual(['happy', 'energized']);
+    });
+
+    it('should include tone tags in individual journal responses', async () => {
+      const date = '2024-01-21';
+      
+      // Create a completed journal with tone tags
+      await testDb()
+        .insert(journals)
+        .values({
+          userId,
+          date,
+          status: 'complete',
+          initialMessage: 'Anxious day',
+          title: 'Anxious Day',
+          synopsis: 'Feeling overwhelmed',
+          toneTags: ['anxious', 'overwhelmed'],
+        });
+
+      // Get individual journal
+      const response = await app.request(`/api/journals/${date}`, {
+        headers: { Authorization: `Bearer ${authToken}` },
+      });
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.success).toBe(true);
+      expect(data.data.toneTags).toEqual(['anxious', 'overwhelmed']);
+    });
+  });
+});

--- a/backend/src/tests/journal-tone-tags.test.ts
+++ b/backend/src/tests/journal-tone-tags.test.ts
@@ -276,7 +276,7 @@ describe('Journal Tone Tags Integration', () => {
           initialMessage: 'Feeling really happy and calm today!',
           chatSession: [
             { role: 'user', content: 'Feeling really happy and calm today!' },
-            { role: 'assistant', content: 'That\'s wonderful to hear! What contributed to those positive feelings?' },
+            { role: 'assistant', content: "That's wonderful to hear! What contributed to those positive feelings?" },
           ],
         });
 
@@ -328,7 +328,7 @@ describe('Journal Tone Tags Integration', () => {
 
     it('should include tone tags in individual journal responses', async () => {
       const date = '2024-01-21';
-      
+
       // Create a completed journal with tone tags
       await testDb()
         .insert(journals)

--- a/backend/src/validation/journals.ts
+++ b/backend/src/validation/journals.ts
@@ -1,5 +1,8 @@
 import { z } from 'zod';
 
+// Import the tone tags from shared types for validation
+const TONE_TAGS = ['happy', 'calm', 'energized', 'overwhelmed', 'sad', 'angry', 'anxious'] as const;
+
 export const createJournalSchema = z.object({
   date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Date must be in YYYY-MM-DD format'),
   initialMessage: z.string().optional(),
@@ -13,6 +16,7 @@ export const updateJournalSchema = z.object({
   summary: z.string().optional(),
   title: z.string().optional(),
   synopsis: z.string().optional(),
+  toneTags: z.array(z.enum(TONE_TAGS)).max(2, 'Maximum 2 tone tags allowed').optional(),
   dayRating: z.number().int().min(1).max(5).optional(),
   inferredDayRating: z.number().int().min(1).max(5).optional(),
 });

--- a/copilot/tasks-prd-gamified-life-app.md
+++ b/copilot/tasks-prd-gamified-life-app.md
@@ -109,6 +109,14 @@
   - [x] 15.3 Update GPT conversation system to use layered context
   - [ ] 15.4 Ensure all journal memory enhancement tests pass
 
+- [ ] 16.0 Emotion Tag Extraction for Journals (Tone Tags)
+  - [x] 16.1 Design and implement tone_tags field in journal schema with database migration (backend)
+  - [x] 16.2 Write backend integration tests for tone tags functionality
+  - [x] 16.3 Implement GPT tone extraction on journal completion (backend)
+  - [x] 16.4 Implement frontend UI for displaying tone tags on journal dashboard
+  - [ ] 16.5 Write frontend E2E tests for tone tags functionality
+  - [ ] 16.6 Ensure all tone tags tests pass
+
 ---
 
 **Relevant files:**

--- a/frontend/src/lib/components/journal/JournalCard.svelte
+++ b/frontend/src/lib/components/journal/JournalCard.svelte
@@ -111,12 +111,7 @@
     <!-- Tone Tags -->
     {#if journal.toneTags && journal.toneTags.length > 0}
       <div class="mt-2">
-        <ToneTagsDisplay 
-          toneTags={journal.toneTags} 
-          size="xs" 
-          showLabels={viewMode === 'list'}
-          maxDisplay={viewMode === 'grid' ? 2 : 4}
-        />
+        <ToneTagsDisplay toneTags={journal.toneTags} size="xs" showLabels={viewMode === 'list'} maxDisplay={viewMode === 'grid' ? 2 : 4} />
       </div>
     {/if}
 

--- a/frontend/src/lib/components/journal/JournalCard.svelte
+++ b/frontend/src/lib/components/journal/JournalCard.svelte
@@ -3,6 +3,7 @@
   import type { JournalListItem } from '$lib/types/journal';
   import { formatDate } from '$lib/utils/date';
   import { BookOpenIcon, MessageSquareIcon, CheckCircleIcon, EditIcon, CalendarIcon, FileTextIcon, TrophyIcon } from 'lucide-svelte';
+  import ToneTagsDisplay from './ToneTagsDisplay.svelte';
 
   export let journal: JournalListItem;
   export let viewMode: 'grid' | 'list' = 'grid';
@@ -104,6 +105,18 @@
         {#if journal.contentTags.length > (viewMode === 'grid' ? 3 : 5)}
           <span class="badge badge-ghost badge-xs">+{journal.contentTags.length - (viewMode === 'grid' ? 3 : 5)}</span>
         {/if}
+      </div>
+    {/if}
+
+    <!-- Tone Tags -->
+    {#if journal.toneTags && journal.toneTags.length > 0}
+      <div class="mt-2">
+        <ToneTagsDisplay 
+          toneTags={journal.toneTags} 
+          size="xs" 
+          showLabels={viewMode === 'list'}
+          maxDisplay={viewMode === 'grid' ? 2 : 4}
+        />
       </div>
     {/if}
 

--- a/frontend/src/lib/components/journal/JournalComplete.svelte
+++ b/frontend/src/lib/components/journal/JournalComplete.svelte
@@ -7,6 +7,7 @@
   import { marked } from 'marked';
   import DOMPurify from 'dompurify';
   import JournalDayRating from './JournalDayRating.svelte';
+  import ToneTagsDisplay from './ToneTagsDisplay.svelte';
 
   export let journal: JournalResponse;
 
@@ -47,6 +48,13 @@
 
       {#if journal.synopsis}
         <p class="text-base-content/80 italic">{journal.synopsis}</p>
+      {/if}
+
+      {#if journal.toneTags && journal.toneTags.length > 0}
+        <div class="mt-4">
+          <h4 class="text-base-content/70 mb-2 text-sm font-medium">Emotional Tone</h4>
+          <ToneTagsDisplay toneTags={journal.toneTags} size="sm" showLabels={true} />
+        </div>
       {/if}
     </div>
   </div>

--- a/frontend/src/lib/components/journal/JournalDashboard.svelte
+++ b/frontend/src/lib/components/journal/JournalDashboard.svelte
@@ -4,6 +4,7 @@
   import { JournalService } from '$lib/api/journal';
   import type { JournalListItem, ListJournalsResponse } from '$lib/types/journal';
   import JournalHeatmap from '$lib/components/journal/JournalHeatmap.svelte';
+  import ToneTagsDisplay from '$lib/components/journal/ToneTagsDisplay.svelte';
   import { BookOpenIcon, CalendarDaysIcon, ListIcon, PlusIcon, SparklesIcon } from 'lucide-svelte';
   import { getTodayDateString, formatDate } from '$lib/utils/date';
 
@@ -80,6 +81,23 @@
   });
   $: bestDay = journalsSortedByRating[0] || null;
   $: worstDay = journalsSortedByRating[journalsSortedByRating.length - 1] || null;
+
+  // Calculate tone tag statistics
+  $: toneTagCounts = completedJournals
+    .filter(j => j.toneTags && j.toneTags.length > 0)
+    .reduce((acc, journal) => {
+      journal.toneTags?.forEach(tag => {
+        acc[tag] = (acc[tag] || 0) + 1;
+      });
+      return acc;
+    }, {} as Record<string, number>);
+
+  $: mostCommonToneTags = Object.entries(toneTagCounts)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 3)
+    .map(([tag, count]) => ({ tag: tag as any, count }));
+
+  $: journalsWithToneTags = completedJournals.filter(j => j.toneTags && j.toneTags.length > 0).length;
 </script>
 
 <div class="space-y-6" data-test-id="journal-dashboard">
@@ -122,7 +140,7 @@
     <!-- Content -->
   {:else}
     <!-- Stats Cards -->
-    <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+    <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">
       <!-- Total Entries -->
       <div class="card bg-base-100 border-base-300 border shadow-sm">
         <div class="card-body p-4">
@@ -184,6 +202,24 @@
           {/if}
         </div>
       </div>
+
+      <!-- Emotional Insights -->
+      <div class="card bg-base-100 border-base-300 border shadow-sm">
+        <div class="card-body p-4">
+          <h3 class="text-base-content/70 card-title text-sm">Emotional Insights</h3>
+          {#if mostCommonToneTags.length > 0}
+            <div class="mt-2 space-y-1">
+              <ToneTagsDisplay toneTags={mostCommonToneTags.map(t => t.tag)} size="xs" showLabels={false} />
+            </div>
+            <div class="text-base-content/60 mt-1 text-xs">
+              From {journalsWithToneTags} analyzed entries
+            </div>
+          {:else}
+            <p class="mt-2 text-2xl font-bold">-</p>
+            <div class="text-base-content/60 mt-1 text-xs">No emotional analysis yet</div>
+          {/if}
+        </div>
+      </div>
     </div>
 
     <!-- Heatmap -->
@@ -209,6 +245,7 @@
                 <tr>
                   <th>Date</th>
                   <th>Title</th>
+                  <th>Mood</th>
                   <th>Rating</th>
                   <th>Status</th>
                 </tr>
@@ -218,6 +255,13 @@
                   <tr class="hover cursor-pointer" on:click={() => goto(`/journal/${journal.date}`)}>
                     <td>{formatDate(journal.date)}</td>
                     <td>{journal.title || 'Untitled'}</td>
+                    <td>
+                      {#if journal.toneTags && journal.toneTags.length > 0}
+                        <ToneTagsDisplay toneTags={journal.toneTags} size="xs" showLabels={false} maxDisplay={2} />
+                      {:else}
+                        <span class="text-base-content/50">-</span>
+                      {/if}
+                    </td>
                     <td>
                       {#if journal.dayRating !== null}
                         <span class="badge">{journal.dayRating}</span>

--- a/frontend/src/lib/components/journal/JournalDashboard.svelte
+++ b/frontend/src/lib/components/journal/JournalDashboard.svelte
@@ -84,20 +84,23 @@
 
   // Calculate tone tag statistics
   $: toneTagCounts = completedJournals
-    .filter(j => j.toneTags && j.toneTags.length > 0)
-    .reduce((acc, journal) => {
-      journal.toneTags?.forEach(tag => {
-        acc[tag] = (acc[tag] || 0) + 1;
-      });
-      return acc;
-    }, {} as Record<string, number>);
+    .filter((j) => j.toneTags && j.toneTags.length > 0)
+    .reduce(
+      (acc, journal) => {
+        journal.toneTags?.forEach((tag) => {
+          acc[tag] = (acc[tag] || 0) + 1;
+        });
+        return acc;
+      },
+      {} as Record<string, number>,
+    );
 
   $: mostCommonToneTags = Object.entries(toneTagCounts)
     .sort((a, b) => b[1] - a[1])
     .slice(0, 3)
     .map(([tag, count]) => ({ tag: tag as any, count }));
 
-  $: journalsWithToneTags = completedJournals.filter(j => j.toneTags && j.toneTags.length > 0).length;
+  $: journalsWithToneTags = completedJournals.filter((j) => j.toneTags && j.toneTags.length > 0).length;
 </script>
 
 <div class="space-y-6" data-test-id="journal-dashboard">
@@ -209,7 +212,7 @@
           <h3 class="text-base-content/70 card-title text-sm">Emotional Insights</h3>
           {#if mostCommonToneTags.length > 0}
             <div class="mt-2 space-y-1">
-              <ToneTagsDisplay toneTags={mostCommonToneTags.map(t => t.tag)} size="xs" showLabels={false} />
+              <ToneTagsDisplay toneTags={mostCommonToneTags.map((t) => t.tag)} size="xs" showLabels={false} />
             </div>
             <div class="text-base-content/60 mt-1 text-xs">
               From {journalsWithToneTags} analyzed entries

--- a/frontend/src/lib/components/journal/JournalFilterBar.svelte
+++ b/frontend/src/lib/components/journal/JournalFilterBar.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
   import { createEventDispatcher } from 'svelte';
-  import { SearchIcon, FilterIcon, CalendarIcon, TagIcon, XIcon } from 'lucide-svelte';
+  import { SearchIcon, FilterIcon, CalendarIcon, TagIcon, HeartIcon, XIcon } from 'lucide-svelte';
+  import { TONE_TAGS, type ToneTag } from '$lib/types/journal';
+  import ToneTagsDisplay from './ToneTagsDisplay.svelte';
 
   export let searchTerm = '';
   export let statusFilter: 'all' | 'draft' | 'in_review' | 'complete' = 'all';
   export let selectedTags: string[] = [];
+  export let selectedToneTags: ToneTag[] = [];
   export let dateFrom = '';
   export let dateTo = '';
   export let availableTags: Array<{ id: string; name: string }> = [];
@@ -35,8 +38,22 @@
     handleFilterChange();
   }
 
+  function toggleToneTag(toneTag: ToneTag) {
+    if (selectedToneTags.includes(toneTag)) {
+      selectedToneTags = selectedToneTags.filter((tag) => tag !== toneTag);
+    } else {
+      selectedToneTags = [...selectedToneTags, toneTag];
+    }
+    handleFilterChange();
+  }
+
   function clearTag(tagId: string) {
     selectedTags = selectedTags.filter((id) => id !== tagId);
+    handleFilterChange();
+  }
+
+  function clearToneTag(toneTag: ToneTag) {
+    selectedToneTags = selectedToneTags.filter((tag) => tag !== toneTag);
     handleFilterChange();
   }
 
@@ -44,6 +61,7 @@
     searchTerm = '';
     statusFilter = 'all';
     selectedTags = [];
+    selectedToneTags = [];
     dateFrom = '';
     dateTo = '';
     handleFilterChange();
@@ -53,7 +71,7 @@
     handleFilterChange();
   }
 
-  $: hasActiveFilters = searchTerm.trim() || statusFilter !== 'all' || selectedTags.length > 0 || dateFrom || dateTo;
+  $: hasActiveFilters = searchTerm.trim() || statusFilter !== 'all' || selectedTags.length > 0 || selectedToneTags.length > 0 || dateFrom || dateTo;
   $: selectedTagNames = selectedTags.map((id) => availableTags.find((tag) => tag.id === id)?.name).filter(Boolean);
 </script>
 
@@ -102,6 +120,19 @@
         {#each selectedTagNames as tagName, index (tagName)}
           <button class="badge badge-primary gap-1" on:click={() => clearTag(selectedTags[index])}>
             {tagName}
+            <XIcon size={12} />
+          </button>
+        {/each}
+      </div>
+    {/if}
+
+    {#if selectedToneTags.length > 0}
+      <div class="mt-2 flex flex-wrap items-center gap-2">
+        <span class="text-base-content/70 text-sm">Mood:</span>
+        {#each selectedToneTags as toneTag (toneTag)}
+          <button class="badge badge-secondary gap-1" on:click={() => clearToneTag(toneTag)}>
+            <ToneTagsDisplay toneTags={[toneTag]} size="xs" showLabels={false} />
+            {toneTag}
             <XIcon size={12} />
           </button>
         {/each}
@@ -197,6 +228,29 @@
             </div>
           </div>
         {/if}
+
+        <!-- Tone Tags Filter -->
+        <div class="form-control">
+          <label class="label">
+            <span class="label-text flex items-center gap-2 font-medium">
+              <HeartIcon size={16} />
+              Mood Tags
+            </span>
+          </label>
+          <div class="flex flex-wrap gap-2">
+            {#each TONE_TAGS as toneTag (toneTag)}
+              <button
+                class="btn btn-sm gap-1"
+                class:btn-secondary={selectedToneTags.includes(toneTag)}
+                class:btn-outline={!selectedToneTags.includes(toneTag)}
+                on:click={() => toggleToneTag(toneTag)}
+              >
+                <ToneTagsDisplay toneTags={[toneTag]} size="xs" showLabels={false} />
+                {toneTag.charAt(0).toUpperCase() + toneTag.slice(1)}
+              </button>
+            {/each}
+          </div>
+        </div>
       </div>
     {/if}
   </div>

--- a/frontend/src/lib/components/journal/ToneTagsDisplay.svelte
+++ b/frontend/src/lib/components/journal/ToneTagsDisplay.svelte
@@ -1,0 +1,85 @@
+<script lang="ts">
+  import type { ToneTag } from '$lib/types/journal';
+  import { HeartIcon, SmileIcon, ZapIcon, CloudIcon, FrownIcon, FlameIcon, AlertTriangleIcon } from 'lucide-svelte';
+
+  export let toneTags: ToneTag[] | null = null;
+  export let size: 'xs' | 'sm' | 'md' = 'sm';
+  export let showLabels = true;
+  export let maxDisplay = 0; // 0 means show all
+
+  // Map tone tags to colors and icons
+  function getToneTagColor(tag: ToneTag): string {
+    switch (tag) {
+      case 'happy':
+        return 'success';
+      case 'calm':
+        return 'info';
+      case 'energized':
+        return 'warning';
+      case 'overwhelmed':
+        return 'error';
+      case 'sad':
+        return 'neutral';
+      case 'angry':
+        return 'error';
+      case 'anxious':
+        return 'warning';
+      default:
+        return 'ghost';
+    }
+  }
+
+  function getToneTagIcon(tag: ToneTag) {
+    switch (tag) {
+      case 'happy':
+        return SmileIcon;
+      case 'calm':
+        return HeartIcon;
+      case 'energized':
+        return ZapIcon;
+      case 'overwhelmed':
+        return CloudIcon;
+      case 'sad':
+        return FrownIcon;
+      case 'angry':
+        return FlameIcon;
+      case 'anxious':
+        return AlertTriangleIcon;
+      default:
+        return SmileIcon;
+    }
+  }
+
+  function getToneTagLabel(tag: ToneTag): string {
+    return tag.charAt(0).toUpperCase() + tag.slice(1);
+  }
+
+  $: displayTags = toneTags 
+    ? (maxDisplay > 0 && toneTags.length > maxDisplay 
+        ? toneTags.slice(0, maxDisplay) 
+        : toneTags)
+    : [];
+
+  $: remainingCount = toneTags && maxDisplay > 0 && toneTags.length > maxDisplay 
+    ? toneTags.length - maxDisplay 
+    : 0;
+</script>
+
+{#if toneTags && toneTags.length > 0}
+  <div class="flex flex-wrap items-center gap-1" data-testid="tone-tags-display">
+    {#each displayTags as tag (tag)}
+      <div class="badge badge-{getToneTagColor(tag)} badge-{size} gap-1">
+        <svelte:component this={getToneTagIcon(tag)} size={size === 'xs' ? 10 : size === 'sm' ? 12 : 14} />
+        {#if showLabels}
+          <span>{getToneTagLabel(tag)}</span>
+        {/if}
+      </div>
+    {/each}
+    
+    {#if remainingCount > 0}
+      <div class="badge badge-ghost badge-{size}">
+        +{remainingCount}
+      </div>
+    {/if}
+  </div>
+{/if}

--- a/frontend/src/lib/components/journal/ToneTagsDisplay.svelte
+++ b/frontend/src/lib/components/journal/ToneTagsDisplay.svelte
@@ -54,15 +54,9 @@
     return tag.charAt(0).toUpperCase() + tag.slice(1);
   }
 
-  $: displayTags = toneTags 
-    ? (maxDisplay > 0 && toneTags.length > maxDisplay 
-        ? toneTags.slice(0, maxDisplay) 
-        : toneTags)
-    : [];
+  $: displayTags = toneTags ? (maxDisplay > 0 && toneTags.length > maxDisplay ? toneTags.slice(0, maxDisplay) : toneTags) : [];
 
-  $: remainingCount = toneTags && maxDisplay > 0 && toneTags.length > maxDisplay 
-    ? toneTags.length - maxDisplay 
-    : 0;
+  $: remainingCount = toneTags && maxDisplay > 0 && toneTags.length > maxDisplay ? toneTags.length - maxDisplay : 0;
 </script>
 
 {#if toneTags && toneTags.length > 0}
@@ -75,7 +69,7 @@
         {/if}
       </div>
     {/each}
-    
+
     {#if remainingCount > 0}
       <div class="badge badge-ghost badge-{size}">
         +{remainingCount}

--- a/frontend/src/lib/types/journal.ts
+++ b/frontend/src/lib/types/journal.ts
@@ -6,11 +6,14 @@ export type {
   UpdateJournalRequest,
   AddChatMessageRequest,
   ChatMessage,
+  ToneTag,
   // Journal Dashboard Types
   ListJournalsRequest,
   ListJournalsResponse,
   JournalListItem,
 } from '../../../../shared/types/journals';
+
+export { TONE_TAGS } from '../../../../shared/types/journals';
 
 // Additional frontend-specific types for UI state
 export interface JournalFormData {

--- a/frontend/src/routes/journal/+page.svelte
+++ b/frontend/src/routes/journal/+page.svelte
@@ -2,7 +2,7 @@
   import { onMount } from 'svelte';
   import { JournalService } from '$lib/api/journal';
   import { goto } from '$app/navigation';
-  import type { ListJournalsResponse, JournalListItem } from '$lib/types/journal';
+  import type { ListJournalsResponse, JournalListItem, ToneTag } from '$lib/types/journal';
   import { BookOpenIcon, SearchIcon, CalendarIcon, FilterIcon, PlusIcon, LayoutGridIcon, LayoutListIcon } from 'lucide-svelte';
   import JournalCard from '$lib/components/journal/JournalCard.svelte';
   import JournalFilterBar from '$lib/components/journal/JournalFilterBar.svelte';
@@ -18,6 +18,7 @@
   let searchTerm = '';
   let statusFilter: 'all' | 'draft' | 'in_review' | 'complete' = 'all';
   let selectedTags: string[] = [];
+  let selectedToneTags: ToneTag[] = [];
   let dateFrom = '';
   let dateTo = '';
   let viewMode: 'grid' | 'list' = 'grid';
@@ -45,6 +46,8 @@
       if (dateFrom) params.dateFrom = dateFrom;
       if (dateTo) params.dateTo = dateTo;
       if (selectedTags.length > 0) params.tagIds = selectedTags;
+      // Note: Backend doesn't support tone tag filtering yet, but frontend is ready
+      // if (selectedToneTags.length > 0) params.toneTags = selectedToneTags;
 
       const response: ListJournalsResponse = await JournalService.listJournals(params);
 
@@ -134,6 +137,7 @@
         bind:searchTerm
         bind:statusFilter
         bind:selectedTags
+        bind:selectedToneTags
         bind:dateFrom
         bind:dateTo
         {availableTags}

--- a/shared/types/journals.ts
+++ b/shared/types/journals.ts
@@ -1,6 +1,10 @@
 // Journal types - shared between backend and frontend
 // Extracted from backend database schema to remove Drizzle dependencies
 
+// Allowed tone tags for emotional analysis
+export const TONE_TAGS = ['happy', 'calm', 'energized', 'overwhelmed', 'sad', 'angry', 'anxious'] as const;
+export type ToneTag = (typeof TONE_TAGS)[number];
+
 export interface Journal {
   id: string;
   userId: string;
@@ -11,6 +15,7 @@ export interface Journal {
   summary: string | null;
   title: string | null;
   synopsis: string | null;
+  toneTags: ToneTag[] | null; // GPT-extracted emotional tone tags (max 2)
   dayRating: number | null;
   inferredDayRating: number | null;
   createdAt: Date;
@@ -27,6 +32,7 @@ export interface NewJournal {
   summary?: string | null;
   title?: string | null;
   synopsis?: string | null;
+  toneTags?: ToneTag[] | null; // GPT-extracted emotional tone tags (max 2)
   dayRating?: number | null;
   inferredDayRating?: number | null;
   createdAt?: Date;
@@ -47,6 +53,7 @@ export interface UpdateJournalRequest {
   summary?: string;
   title?: string;
   synopsis?: string;
+  toneTags?: ToneTag[]; // GPT-extracted emotional tone tags (max 2)
   dayRating?: number; // User-provided rating (1-5)
   inferredDayRating?: number; // AI-inferred rating (1-5)
 }
@@ -87,6 +94,7 @@ export interface JournalListItem {
   title: string | null;
   synopsis: string | null;
   initialMessage: string | null;
+  toneTags: ToneTag[] | null; // GPT-extracted emotional tone tags
   dayRating: number | null;
   inferredDayRating: number | null;
   createdAt: string;
@@ -117,6 +125,7 @@ export interface JournalResponse {
   summary: string | null;
   title: string | null;
   synopsis: string | null;
+  toneTags: ToneTag[] | null; // GPT-extracted emotional tone tags
   dayRating: number | null;
   inferredDayRating: number | null;
   createdAt: string;

--- a/tests/e2e/journal-rating.spec.ts
+++ b/tests/e2e/journal-rating.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { loginUser } from './test-helpers';
+import { TEST_CONFIG } from './test-config';
 
 test.describe('Journal Day Rating', () => {
   test.beforeEach(async ({ page }) => {
@@ -10,7 +11,7 @@ test.describe('Journal Day Rating', () => {
   async function cleanupJournal(page: any, date: string) {
     try {
       const authToken = (await page.evaluate('localStorage.getItem("token")')) || '';
-      await page.request.delete(`/api/journals/${date}`, {
+      await page.request.delete(`${TEST_CONFIG.API_BASE_URL}/api/journals/${date}`, {
         headers: {
           Authorization: `Bearer ${authToken}`,
         },

--- a/tests/e2e/journal-tone-tags.spec.ts
+++ b/tests/e2e/journal-tone-tags.spec.ts
@@ -1,0 +1,113 @@
+import { test, expect } from '@playwright/test';
+import { loginUser } from './test-helpers';
+import { TEST_CONFIG } from './test-config';
+
+test.describe('Journal Tone Tags Feature', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginUser(page);
+    await page.waitForLoadState('networkidle');
+  });
+
+  async function createJournalWithToneTags(page: any, date: string, toneTags: string[]) {
+    // Get auth token
+    const authToken = (await page.evaluate('localStorage.getItem("token")')) || '';
+
+    // Clean up any existing journal for this date
+    try {
+      await page.request.delete(`${TEST_CONFIG.API_BASE_URL}/api/journals/${date}`, {
+        headers: { Authorization: `Bearer ${authToken}` },
+      });
+    } catch (error) {
+      // Ignore - journal might not exist
+    }
+
+    // Create a completed journal with tone tags directly via API
+    const response = await page.request.post(`${TEST_CONFIG.API_BASE_URL}/api/journals`, {
+      headers: {
+        Authorization: `Bearer ${authToken}`,
+        'Content-Type': 'application/json',
+      },
+      data: {
+        date: date,
+        initialMessage: 'Test journal content for tone tags',
+      },
+    });
+
+    // Update the journal to completed status with tone tags
+    await page.request.put(`${TEST_CONFIG.API_BASE_URL}/api/journals/${date}`, {
+      headers: {
+        Authorization: `Bearer ${authToken}`,
+        'Content-Type': 'application/json',
+      },
+      data: {
+        status: 'complete',
+        title: 'Test Journal',
+        synopsis: 'A test journal with tone tags',
+        toneTags: toneTags,
+        summary: 'This is a test journal entry.',
+      },
+    });
+  }
+
+  test('displays tone tags in completed journal', async ({ page }) => {
+    const testDate = '2025-01-15';
+    const testToneTags = ['happy', 'energized'];
+
+    await createJournalWithToneTags(page, testDate, testToneTags);
+
+    // Navigate to the journal
+    await page.goto(`/journal/${testDate}`);
+    await page.waitForLoadState('networkidle');
+
+    // Should show completed journal
+    await expect(page.locator('[data-test-id="journal-complete"]')).toBeVisible();
+
+    // Should display tone tags
+    const toneTagsDisplay = page.locator('[data-testid="tone-tags-display"]');
+    await expect(toneTagsDisplay).toBeVisible();
+
+    // Should show the happy badge
+    await expect(page.locator('.badge').filter({ hasText: /happy/i })).toBeVisible();
+  });
+
+  test('shows tone tag filtering UI', async ({ page }) => {
+    // Navigate to journal listing page
+    const testDate = '2025-01-15';
+    const testToneTags = ['happy', 'energized'];
+
+    await createJournalWithToneTags(page, testDate, testToneTags);
+
+    await page.goto('/journal');
+    await page.waitForLoadState('networkidle');
+
+    // Open filters
+    await page.locator('button').filter({ hasText: 'Filters' }).click();
+
+    // Should show tone tag filtering section
+    await expect(page.locator('text=Mood Tags')).toBeVisible();
+
+    // Should show tone tag filter buttons
+    await expect(page.locator('button').filter({ hasText: /^Happy$/i })).toBeVisible();
+    await expect(page.locator('button').filter({ hasText: /^Calm$/i })).toBeVisible();
+  });
+
+  test('displays tone tags in journal dashboard', async ({ page }) => {
+    const testDate = '2025-01-15';
+    const testToneTags = ['happy', 'energized'];
+
+    await createJournalWithToneTags(page, testDate, testToneTags);
+
+    await page.goto('/journals');
+    await page.waitForLoadState('networkidle');
+
+    // Check if journal dashboard displays emotional insights section
+    const dashboardElement = page.locator('[data-test-id="journal-dashboard"]');
+    await expect(dashboardElement).toBeVisible();
+
+    // Should show the emotional insights card
+    await expect(page.locator('text=Emotional Insights')).toBeVisible();
+
+    // Should show mood column in recent entries table
+    await expect(page.locator('th').filter({ hasText: 'Mood' })).toBeVisible();
+  });
+});

--- a/tests/e2e/journal.spec.ts
+++ b/tests/e2e/journal.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { loginUser } from './test-helpers';
+import { TEST_CONFIG } from './test-config';
 
 test.describe('Journal System', () => {
   test.beforeEach(async ({ page }) => {
@@ -10,7 +11,7 @@ test.describe('Journal System', () => {
   async function cleanupJournal(page: any, date: string) {
     try {
       const authToken = (await page.evaluate('localStorage.getItem("token")')) || '';
-      await page.request.delete(`/api/journals/${date}`, {
+      await page.request.delete(`${TEST_CONFIG.API_BASE_URL}/api/journals/${date}`, {
         headers: {
           Authorization: `Bearer ${authToken}`,
         },


### PR DESCRIPTION
Introduce a new `tone_tags` field in the journal schema to store emotional tone tags extracted by GPT. Update the frontend to display these tone tags in the journal dashboard and implement validation for tone tags in the journal forms.